### PR TITLE
Update tests after option to delete all sensors was removed

### DIFF
--- a/src/main/java/selenium/base/TestCommons.java
+++ b/src/main/java/selenium/base/TestCommons.java
@@ -170,18 +170,6 @@ public abstract class TestCommons {
             }
         });
     }
-
-    protected static boolean isElementNotDisplayed(WebDriver driver, WebElement element) {
-        try {
-            WebDriverWait wait = new WebDriverWait(driver, 10);
-            wait.until(ExpectedConditions.invisibilityOf(element));
-            return !(element.isDisplayed());
-        } catch (org.openqa.selenium.NoSuchElementException
-                | org.openqa.selenium.StaleElementReferenceException
-                | org.openqa.selenium.TimeoutException e) {
-            return true;
-        }
-    }
 }
 
 

--- a/src/main/java/selenium/pages/AddSensorOnHomePlanPage.java
+++ b/src/main/java/selenium/pages/AddSensorOnHomePlanPage.java
@@ -7,6 +7,8 @@ import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 import selenium.base.TestCommons;
 
+import java.util.List;
+
 
 public class AddSensorOnHomePlanPage extends TestCommons {
 
@@ -17,7 +19,7 @@ public class AddSensorOnHomePlanPage extends TestCommons {
     public WebElement secondNotConnectedSensor;
 
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[2]/li[2]")
-    public WebElement connectedSensor;
+    public WebElement firstConnectedSensor;
 
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
     public WebElement homePlan;
@@ -37,16 +39,21 @@ public class AddSensorOnHomePlanPage extends TestCommons {
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/div[last()]")
     public WebElement pointOnHomePlan;
 
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[1]")
+    public WebElement notConnectedSensorsList;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[2]")
+    public WebElement connectedSensorsList;
+
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div/div[3]/button[2]")
+    public WebElement okButtonOnDeletingSensorBox;
+
     public AddSensorOnHomePlanPage(WebDriver driver) {
         super(driver);
     }
 
     public void goTo() {
         goTo("/");
-    }
-
-    public void clearHomePlan() {
-        goTo("/api/v1/dashboard/delete");
     }
 
     public String getColorOfSensorLeftBorder(WebElement element) {
@@ -67,7 +74,7 @@ public class AddSensorOnHomePlanPage extends TestCommons {
     }
 
     public String isSensorNotClickable() {
-        return getElementAttribute(connectedSensor, "aria-disabled");
+        return getElementAttribute(firstConnectedSensor, "aria-disabled");
     }
 
     public String getTextFromElement(WebElement element) {
@@ -135,5 +142,39 @@ public class AddSensorOnHomePlanPage extends TestCommons {
                 throw new IllegalStateException("Unexpected value: " + getSensorType(element));
         }
     }
+
+    public void deleteFirstSensorFromHomePlan() {
+        clickElement(firstConnectedSensor);
+        clickElement(firstConnectedSensor.findElement(By.tagName("button")));
+        clickElement(okButtonOnDeletingSensorBox);
+    }
+
+    public void deleteSensorsWhenRequired() {
+        while (connectedSensorsOnList().size() != 0) {
+            String firstConnectedSensorId = getSensorId(firstConnectedSensor);
+            deleteFirstSensorFromHomePlan();
+            waitForDeletedSensor(firstConnectedSensorId);
+        }
+
+    }
+
+    public List<WebElement> connectedSensorsOnList() {
+        List<WebElement> allNotConnectedSensorsOnList = connectedSensorsList.findElements(By.tagName("li"));
+        allNotConnectedSensorsOnList.remove(0);
+        return allNotConnectedSensorsOnList;
+    }
+
+    public void waitForDeletedSensor(String idText) {
+        isElementDisplayed(driver, notConnectedSensorById(idText));
+    }
+
+    public WebElement notConnectedSensorById(String idText) {
+        return notConnectedSensorsList.findElement(By.id(idText));
+    }
+
+    public String getSensorId(WebElement element) {
+        return getElementAttribute(element, "id");
+    }
+
 
 }

--- a/src/main/java/selenium/pages/DashboardPage.java
+++ b/src/main/java/selenium/pages/DashboardPage.java
@@ -1,5 +1,6 @@
 package selenium.pages;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -27,8 +28,11 @@ public class DashboardPage extends TestCommons {
     @FindBy(tagName = "img")
     public WebElement homePlan;
 
-    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/div[last()]")
-    public WebElement lastPoint;
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div")
+    public WebElement homePlanByDiv;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/div[2]")
+    public WebElement secondPoint;
 
     @FindBy(xpath = "/html/body/div[2]/div[3]")
     public WebElement gapNeededBox;
@@ -38,6 +42,15 @@ public class DashboardPage extends TestCommons {
 
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[1]/li[2]")
     public WebElement firstNotConnectedSensor;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[1]/li[last()]")
+    public WebElement lastNotConnectedSensor;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[2]/li[2]")
+    public WebElement firstConnectedSensor;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[2]/li[3]")
+    public WebElement secondConnectedSensor;
 
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[1]/header/div/div[2]/div/div/div")
     public WebElement languageListBox;
@@ -51,16 +64,21 @@ public class DashboardPage extends TestCommons {
     @FindBy(id = "root")
     public WebElement notificationBackground;
 
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[1]")
+    public WebElement notConnectedSensorsList;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[2]")
+    public WebElement connectedSensorsList;
+
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div/div[3]/button[2]")
+    public WebElement okButtonOnDeletingSensorBox;
+
     public DashboardPage(WebDriver driver) {
         super(driver);
     }
 
     public void goTo() {
         goTo("/");
-    }
-
-    public void clearHomePlan() {
-        goTo("/api/v1/dashboard/delete");
     }
 
     public int getNumberOfSections() {
@@ -142,7 +160,7 @@ public class DashboardPage extends TestCommons {
 
     public void clickToAddPoint(int xOffset, int yOffset) {
         Actions builder = new Actions(driver);
-        builder.moveToElement(homePlan, xOffset, yOffset).click().perform();
+        builder.moveToElement(homePlanByDiv, xOffset, yOffset).click().perform();
     }
 
     public void clickOffsetToGapNeededBox(int xOffset, int yOffset) {
@@ -156,23 +174,23 @@ public class DashboardPage extends TestCommons {
     }
 
     public String getPointUniqueInformation() {
-        return getElementAttribute(lastPoint, "style");
+        return getElementAttribute(secondPoint, "style");
     }
 
-    public int getLastPointWidth() {
-        return getElementWidth(lastPoint);
+    public int getSecondPointWidth() {
+        return getElementWidth(secondPoint);
     }
 
-    public int getLastPointHeight() {
-        return getElementHeight(lastPoint);
+    public int getSecondPointHeight() {
+        return getElementHeight(secondPoint);
     }
 
     public int getPointX() {
-        return getElementLocation(lastPoint).getX();
+        return getElementLocation(secondPoint).getX();
     }
 
     public int getPointY() {
-        return getElementLocation(lastPoint).getY();
+        return getElementLocation(secondPoint).getY();
     }
 
     public int getMapX() {
@@ -220,7 +238,7 @@ public class DashboardPage extends TestCommons {
 
     public boolean isLoaderDisplayed(WebElement element) throws InterruptedException {
 
-        long endWaitTime = System.currentTimeMillis() + 1* 1000;
+        long endWaitTime = System.currentTimeMillis() + 1 * 1000;
         boolean isConditionMet = false;
         while (System.currentTimeMillis() < endWaitTime && !isConditionMet) {
             isConditionMet = element.isDisplayed();
@@ -245,6 +263,61 @@ public class DashboardPage extends TestCommons {
 
     public void waitUntilHomePlanIsLoaded() {
         waitUntilVisible(driver, homePlan);
+    }
+
+    public void deleteFirstSensorFromHomePlan() {
+        clickElement(firstConnectedSensor);
+        clickElement(firstConnectedSensor.findElement(By.tagName("button")));
+        clickElement(okButtonOnDeletingSensorBox);
+    }
+
+    public void deleteSecondSensorFromHomePlan() {
+        clickElement(secondConnectedSensor);
+        clickElement(secondConnectedSensor.findElement(By.tagName("button")));
+        clickElement(okButtonOnDeletingSensorBox);
+    }
+
+    public void deleteSensorsWhenRequired() {
+        while (connectedSensorsOnList().size() != 0) {
+            String firstConnectedSensorId = getSensorId(firstConnectedSensor);
+            deleteFirstSensorFromHomePlan();
+            waitForDeletedSensor(firstConnectedSensorId);
+        }
+
+    }
+
+    public List<WebElement> connectedSensorsOnList() {
+        List<WebElement> allNotConnectedSensorsOnList = connectedSensorsList.findElements(By.tagName("li"));
+        allNotConnectedSensorsOnList.remove(0);
+        return allNotConnectedSensorsOnList;
+    }
+
+    public void clickOnCoordinates(int xOffset, int yOffset) {
+        Actions builder = new Actions(driver);
+        builder.moveByOffset(xOffset, yOffset).click().perform();
+    }
+
+    public void addPointsOnHomePlanWhenRequired(int x, int y) {
+        if (connectedSensorsOnList().size() == 0) {
+            clickElement(lastNotConnectedSensor);
+            clickToAddPoint(x, y); //First sensor
+            clickOnCoordinates(60, 180); // In case Gap Needed box is present, it will close the box
+            clickElement(lastNotConnectedSensor);
+            clickToAddPoint(x, y + 50); //Second sensor
+            clickOnCoordinates(60, 180); // In case Gap Needed box is present, it will close the box
+        }
+    }
+
+    public void waitForDeletedSensor(String idText) {
+        isElementDisplayed(driver, notConnectedSensorById(idText));
+    }
+
+    public WebElement notConnectedSensorById(String idText) {
+        return notConnectedSensorsList.findElement(By.id(idText));
+    }
+
+    public String getSensorId(WebElement element) {
+        return getElementAttribute(element, "id");
     }
 
 }

--- a/src/main/java/selenium/pages/DeleteSensorFromHomePlanPage.java
+++ b/src/main/java/selenium/pages/DeleteSensorFromHomePlanPage.java
@@ -50,6 +50,10 @@ public class DeleteSensorFromHomePlanPage extends TestCommons {
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[3]")
     public WebElement snackbarBox;
 
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/div[1]")
+    public WebElement firstSensorOnHomePlan;
+
+
     public DeleteSensorFromHomePlanPage(WebDriver driver) {
         super(driver);
     }
@@ -58,17 +62,17 @@ public class DeleteSensorFromHomePlanPage extends TestCommons {
         goTo("/");
     }
 
-    public void clearHomePlan() {
-        goTo("/api/v1/dashboard/delete");
-    }
-
     public void clickSensorOnList(WebElement element) {
         clickElement(element);
     }
 
     public void clickOnHomePlan(int xOffset, int yOffset) {
         Actions builder = new Actions(driver);
-        builder.moveToElement(homePlan, xOffset, yOffset).click().perform();
+        builder.moveToElement(homePlanByDiv, xOffset, yOffset).click().perform();
+    }
+
+    public void clickSensorOnHomePlan() {
+        firstSensorOnHomePlan.click();
     }
 
     public WebElement deleteButton(WebElement element) {
@@ -164,8 +168,27 @@ public class DeleteSensorFromHomePlanPage extends TestCommons {
         return !isConditionMet;
     }
 
-    public void waitUntilHomePlanIsLoaded() {
-        waitUntilVisible(driver, homePlan);
+    public void clickOnCoordinates(int xOffset, int yOffset) {
+        Actions builder = new Actions(driver);
+        builder.moveByOffset(xOffset, yOffset).click().perform();
     }
 
+    public void addPointsOnHomePlan(int x, int y) {
+        if (pointsOnHomePlan().size() < 3) {
+            clickSensorOnList(firstNotConnectedSensor);
+            clickOnHomePlan(x, y); //First sensor
+            clickOnCoordinates(60, 180); // In case Gap Needed box is present, it will close the box
+            clickSensorOnList(firstNotConnectedSensor);
+            clickOnHomePlan(x, y + 50); //Second sensor
+            clickOnCoordinates(60, 180); // In case Gap Needed box is present, it will close the box
+            clickSensorOnList(firstNotConnectedSensor);
+            clickOnHomePlan(x + 50, y); //Third sensor
+            clickOnCoordinates(60, 180); // In case Gap Needed box is present, it will close the box
+        }
+    }
+
+    public void addPointsOnHomePlanWhenRequired() {
+        addPointsOnHomePlan(0, 0);
+        addPointsOnHomePlan(20, 20);
+    }
 }

--- a/src/main/java/selenium/pages/MarkSensorOnHomePlanPage.java
+++ b/src/main/java/selenium/pages/MarkSensorOnHomePlanPage.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.support.FindBy;
 import selenium.base.TestCommons;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class MarkSensorOnHomePlanPage extends TestCommons {
@@ -16,11 +17,14 @@ public class MarkSensorOnHomePlanPage extends TestCommons {
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
     public WebElement homePlan;
 
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/div[1]")
+    public WebElement firstSensorOnHomePlan;
+
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/div[last()]")
-    public WebElement sensorOnHomePlan;
+    public WebElement lastSensorOnHomePlan;
 
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[2]/li[last()]")
-    public WebElement sensorOnConnectedSensorsList;
+    public WebElement lastSensorOnConnectedSensorsList;
 
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/div[2]")
     public WebElement secondSensorOnHomePlan;
@@ -28,16 +32,18 @@ public class MarkSensorOnHomePlanPage extends TestCommons {
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[2]/li[3]")
     public WebElement secondSensorOnConnectedSensorsList;
 
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[2]/ul[2]")
+    public WebElement connectedSensorsList;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div")
+    public WebElement homePlanByDiv;
+
     public MarkSensorOnHomePlanPage(WebDriver driver) {
         super(driver);
     }
 
     public void goTo() {
         goTo("/");
-    }
-
-    public void clearHomePlan() {
-        goTo("/api/v1/dashboard/delete");
     }
 
     public String getElementBackgroundColor(WebElement element) {
@@ -53,18 +59,18 @@ public class MarkSensorOnHomePlanPage extends TestCommons {
     }
 
     public void clickLastSensorOnHomePlan() {
-        clickElement(sensorOnHomePlan);
+        clickElement(lastSensorOnHomePlan);
     }
 
     public void clickOnHomePlan(int xOffset, int yOffset) {
         Actions builder = new Actions(driver);
-        builder.moveToElement(homePlan, xOffset, yOffset).click().perform();
+        builder.moveToElement(homePlanByDiv, xOffset, yOffset).click().perform();
     }
 
     public void resizeBrowser() {
         Dimension browserDimension = driver.manage().window().getSize();
         int xBrowser = browserDimension.getWidth();
-        int yBrowser = (int) ((browserDimension.getHeight())*0.7);
+        int yBrowser = (int) ((browserDimension.getHeight()) * 0.7);
         Dimension dimension = new Dimension(xBrowser, yBrowser);
         driver.manage().window().setSize(dimension);
     }
@@ -80,7 +86,7 @@ public class MarkSensorOnHomePlanPage extends TestCommons {
 
     public void waitForScrollToComplete(WebElement element) throws InterruptedException {
 
-        long endWaitTime = System.currentTimeMillis() + 5* 1000;
+        long endWaitTime = System.currentTimeMillis() + 5 * 1000;
         boolean isConditionMet = false;
         while (System.currentTimeMillis() < endWaitTime && !isConditionMet) {
             isConditionMet = isSensorInViewPort(element);
@@ -129,6 +135,50 @@ public class MarkSensorOnHomePlanPage extends TestCommons {
         backgroundAndBorderColor.put("rgba(255, 141, 133, 1)", "rgb(235, 16, 0)");
         backgroundAndBorderColor.put("rgba(128, 128, 128, 1)", "rgb(51, 51, 51)");
         return backgroundAndBorderColor;
+    }
+
+    public List<WebElement> pointsOnHomePlan() {
+        List<WebElement> allPointsOnHomePlan = homePlanByDiv.findElements(By.tagName("div"));
+        return allPointsOnHomePlan;
+    }
+
+    public void clickOnCoordinates(int xOffset, int yOffset) {
+        Actions builder = new Actions(driver);
+        builder.moveByOffset(xOffset, yOffset).click().perform();
+    }
+
+    public void addPointsOnHomePlan(int x, int y) {
+        if (pointsOnHomePlan().size() < 5) {
+            clickFirstNotConnectedSensorOnList();
+            clickOnHomePlan(x, y);
+            clickOnCoordinates(60, 180); // In case Gap Needed box is present, it will close the box
+        }
+    }
+
+    public void addPointsOnHomePlanWhenRequired() {
+        addPointsOnHomePlan(0, 0);
+        addPointsOnHomePlan(0, 20);
+        addPointsOnHomePlan(0, 40);
+        addPointsOnHomePlan(0, 80);
+        addPointsOnHomePlan(0, 100);
+        addPointsOnHomePlan(20, 0);
+        addPointsOnHomePlan(40, 0);
+        addPointsOnHomePlan(80, 0);
+        addPointsOnHomePlan(100, 0);
+        addPointsOnHomePlan(20, 20);
+        addPointsOnHomePlan(40, 40);
+        addPointsOnHomePlan(80, 80);
+        addPointsOnHomePlan(100, 100);
+    }
+
+    public void clickSensorOnHomePlan(WebElement element) {
+        clickElement(element);
+    }
+
+    public List<WebElement> sensorsOnList() {
+        List<WebElement> allSensorsOnHomePlan = connectedSensorsList.findElements(By.tagName("li"));
+        allSensorsOnHomePlan.remove(0);
+        return allSensorsOnHomePlan;
     }
 
 }

--- a/src/test/java/selenium/AddSensorOnHomePlanTest.java
+++ b/src/test/java/selenium/AddSensorOnHomePlanTest.java
@@ -2,7 +2,7 @@ package selenium;
 
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import selenium.base.TestBase;
 import selenium.pages.AddSensorOnHomePlanPage;
@@ -12,11 +12,11 @@ public class AddSensorOnHomePlanTest extends TestBase {
 
     private AddSensorOnHomePlanPage addSensorOnMapPage;
 
-    @BeforeMethod
-    public void beforeMethod() {
+    @BeforeClass
+    public void beforeClass() {
         addSensorOnMapPage = new AddSensorOnHomePlanPage(driver);
-        addSensorOnMapPage.clearHomePlan();
         addSensorOnMapPage.goTo();
+        addSensorOnMapPage.deleteSensorsWhenRequired();
     }
 
     @Test
@@ -29,7 +29,7 @@ public class AddSensorOnHomePlanTest extends TestBase {
         addSensorOnMapPage.waitForCompleteBackgroundColor(element);
         String selectedSensorBackgroundColor = addSensorOnMapPage.getElementBackgroundColor(element);
         String notSelectedSensorBackgroundColor = addSensorOnMapPage.getElementBackgroundColor(secondElement);
-        String whiteBackgroundColor = "rgba(0, 0, 0, 0)";
+        String whiteBackgroundColor = "rgba(255, 255, 255, 1)";
 
         Assert.assertEquals(selectedSensorBackgroundColor, sensorTypeBackgroundColor, "Sensor background color is not matching sensor color");
         Assert.assertEquals(notSelectedSensorBackgroundColor, whiteBackgroundColor, "Not selected sensor background color is not white");

--- a/src/test/java/selenium/DeleteSensorFromHomePlanTest.java
+++ b/src/test/java/selenium/DeleteSensorFromHomePlanTest.java
@@ -15,21 +15,14 @@ public class DeleteSensorFromHomePlanTest extends TestBase {
     @BeforeClass
     public void beforeClass() {
         deleteSensorFromHomePlanPage = new DeleteSensorFromHomePlanPage(driver);
-        deleteSensorFromHomePlanPage.clearHomePlan();
         deleteSensorFromHomePlanPage.goTo();
-        deleteSensorFromHomePlanPage.waitUntilHomePlanIsLoaded();
-        deleteSensorFromHomePlanPage.clickSensorOnList(deleteSensorFromHomePlanPage.firstNotConnectedSensor);
-        deleteSensorFromHomePlanPage.clickOnHomePlan(0, 50); //First sensor
-        deleteSensorFromHomePlanPage.clickSensorOnList(deleteSensorFromHomePlanPage.firstNotConnectedSensor);
-        deleteSensorFromHomePlanPage.clickOnHomePlan(0, -50); //Second sensor
-        deleteSensorFromHomePlanPage.clickSensorOnList(deleteSensorFromHomePlanPage.firstNotConnectedSensor);
-        deleteSensorFromHomePlanPage.clickOnHomePlan(0, 0); //Third sensor
+        deleteSensorFromHomePlanPage.addPointsOnHomePlanWhenRequired();
     }
 
     @Test
     public void testAPresenceOfDeleteButtonOnSensor() {
 
-        deleteSensorFromHomePlanPage.clickOnHomePlan(0, 50); //Select sensor on map
+        deleteSensorFromHomePlanPage.clickSensorOnHomePlan();
         Assert.assertEquals(deleteSensorFromHomePlanPage.isDeleteButtonDisplayed(deleteSensorFromHomePlanPage.firstConnectedSensor), "block");
         deleteSensorFromHomePlanPage.clickSensorOnList(deleteSensorFromHomePlanPage.secondConnectedSensor); //Select sensor on list
         Assert.assertEquals(deleteSensorFromHomePlanPage.isDeleteButtonDisplayed(deleteSensorFromHomePlanPage.secondConnectedSensor), "block");
@@ -79,5 +72,4 @@ public class DeleteSensorFromHomePlanTest extends TestBase {
         Assert.assertEquals(connectedSensorsAfterDeletingOnline, connectedSensors - 1);
         Assert.assertTrue(deleteSensorFromHomePlanPage.isSnackbarNotDisplayed(), "Snackbar is displayed");
     }
-
 }

--- a/src/test/java/selenium/MapTest.java
+++ b/src/test/java/selenium/MapTest.java
@@ -8,11 +8,12 @@ import selenium.pages.DashboardPage;
 public class MapTest extends TestBase {
     private DashboardPage dashboardPage;
 
-    @BeforeMethod
-    public void beforeMethod() {
+    @BeforeClass
+    public void beforeClass() {
         dashboardPage = new DashboardPage(driver);
-        dashboardPage.clearHomePlan();
         dashboardPage.goTo();
+        dashboardPage.deleteSensorsWhenRequired();
+        dashboardPage.addPointsOnHomePlanWhenRequired(-50, -100);
     }
 
     @Test
@@ -27,14 +28,17 @@ public class MapTest extends TestBase {
     public Object[] incorrectOffsets() {
         int incorrectOffsetHeight = dashboardPage.incorrectOffsetHeight();
         int incorrectOffsetWidth = dashboardPage.incorrectOffsetWidth();
-        return new Object[][]{{0, 100 + incorrectOffsetHeight}, {0, (100 - incorrectOffsetHeight)}, {-(incorrectOffsetWidth), 100}, {(incorrectOffsetWidth), 100}};
+        return new Object[][]{{0, (-100 + incorrectOffsetHeight)}, {0, (-100 - incorrectOffsetHeight)}, {-(incorrectOffsetWidth), -100}, {(incorrectOffsetWidth), -100}};
     }
 
     @Test(dataProvider = "incorrectOffsets")
     public void testAddingPointWithin3percentCircle(Integer x, Integer y) {
         dashboardPage.waitUntilHomePlanIsLoaded();
+        String secondSensorId = dashboardPage.getSensorId(dashboardPage.secondConnectedSensor);
+        dashboardPage.deleteSecondSensorFromHomePlan();
+        dashboardPage.waitForDeletedSensor(secondSensorId);
         dashboardPage.clickFirstNotConnectedSensor();
-        dashboardPage.clickToAddPoint(0, 100);
+        dashboardPage.clickToAddPoint(0, -100);
         String lastPointBeforeClick = dashboardPage.getPointUniqueInformation();
         dashboardPage.clickFirstNotConnectedSensor();
         dashboardPage.clickToAddPoint(x, y);
@@ -58,12 +62,15 @@ public class MapTest extends TestBase {
         dashboardPage.waitUntilHomePlanIsLoaded();
         dashboardPage.clickFirstNotConnectedSensor();
         dashboardPage.clickToAddPoint(0, 0);
-        String lastPointBeforeClick = dashboardPage.getPointUniqueInformation();
+        String secondPointBeforeClick = dashboardPage.getPointUniqueInformation();
         dashboardPage.clickFirstNotConnectedSensor();
         dashboardPage.clickToAddPoint(x, y);
-        String lastPointAfterClick = dashboardPage.getPointUniqueInformation();
-        Assert.assertNotEquals(lastPointAfterClick, lastPointBeforeClick, "Point was not added on home plan");
-        Assert.assertEquals(dashboardPage.getLastPointWidth(), dashboardPage.getLastPointHeight(), "Point is not a circle");  //Check if point is a circle
+        String secondPointAfterClick = dashboardPage.getPointUniqueInformation();
+        Assert.assertNotEquals(secondPointAfterClick, secondPointBeforeClick, "Point was not added on home plan");
+        Assert.assertEquals(dashboardPage.getSecondPointWidth(), dashboardPage.getSecondPointHeight(), "Point is not a circle");  //Check if point is a circle
+        String secondSensorId = dashboardPage.getSensorId(dashboardPage.secondConnectedSensor);
+        dashboardPage.deleteSecondSensorFromHomePlan();
+        dashboardPage.waitForDeletedSensor(secondSensorId);
     }
 
     @Test

--- a/src/test/java/selenium/MarkSensorOnHomePlanTest.java
+++ b/src/test/java/selenium/MarkSensorOnHomePlanTest.java
@@ -3,10 +3,11 @@ package selenium;
 import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import selenium.base.TestBase;
 import selenium.pages.MarkSensorOnHomePlanPage;
+
+import java.util.List;
 
 
 public class MarkSensorOnHomePlanTest extends TestBase {
@@ -15,39 +16,34 @@ public class MarkSensorOnHomePlanTest extends TestBase {
     @BeforeClass
     public void beforeClass() {
         markSensorOnHomePlanPage = new MarkSensorOnHomePlanPage(driver);
-        markSensorOnHomePlanPage.clearHomePlan();
         markSensorOnHomePlanPage.goTo();
+        markSensorOnHomePlanPage.addPointsOnHomePlanWhenRequired();
     }
 
-    @DataProvider(name = "positionsOnHomePlan")
-    public Object[][] positionsOnHomePlan() {
-        return new Object[][]{{0, 0}, {-100, 0}, {100, 0}, {0, -100}, {0, 100}};
-    }
-
-    @Test(dataProvider = "positionsOnHomePlan")
-    public void testABorderOfSelectedSensorOnHomePlan(Integer x, Integer y) {
-        markSensorOnHomePlanPage.clickFirstNotConnectedSensorOnList();
-        markSensorOnHomePlanPage.clickOnHomePlan(x, y);  // Add sensor on home plan
-        markSensorOnHomePlanPage.clickOnHomePlan(x, y);  // Click on sensor on home plan to select it
-
-        String actualSensorOnHomePlanBorderColor = markSensorOnHomePlanPage.getElementBorderColor(markSensorOnHomePlanPage.sensorOnHomePlan);
-        String actualSensorOnConnectedSensorsListBackgroundColor = markSensorOnHomePlanPage.getElementBackgroundColor(markSensorOnHomePlanPage.sensorOnConnectedSensorsList);
-        String sensorOnHomePlanBackgroundColor = markSensorOnHomePlanPage.getElementBackgroundColor(markSensorOnHomePlanPage.sensorOnHomePlan);
-        String expectedSensorOnHomePlanBorderColor = markSensorOnHomePlanPage.sensorBackgroundAndBorderColorMap().get(sensorOnHomePlanBackgroundColor);
-        String expectedCharSequenceInBackgroundColor = markSensorOnHomePlanPage.getSensorTypeBackgroundColor(markSensorOnHomePlanPage.sensorOnConnectedSensorsList);
-
-        Assert.assertEquals(actualSensorOnHomePlanBorderColor, expectedSensorOnHomePlanBorderColor); //Check if selected sensor on home plan has border color of color matching sensor type
-        Assert.assertTrue(actualSensorOnConnectedSensorsListBackgroundColor.contains(expectedCharSequenceInBackgroundColor)); //Check if selected sensor on connected sensors list has background color of color matching sensor type
+    @Test
+    public void testABorderOfSelectedSensorOnHomePlan() {
+        List<WebElement> allPointsOnHomePlan = markSensorOnHomePlanPage.pointsOnHomePlan();
+        List<WebElement> allConnectedSensors = markSensorOnHomePlanPage.sensorsOnList();
+        for (int i = 0; i < allPointsOnHomePlan.size(); i++) {
+            markSensorOnHomePlanPage.clickSensorOnHomePlan(allPointsOnHomePlan.get(i));  // Click on sensor on home plan to select it
+            String actualSensorOnHomePlanBorderColor = markSensorOnHomePlanPage.getElementBorderColor(allPointsOnHomePlan.get(i));
+            String actualSensorOnConnectedSensorsListBackgroundColor = markSensorOnHomePlanPage.getElementBackgroundColor(allConnectedSensors.get(i));
+            String sensorOnHomePlanBackgroundColor = markSensorOnHomePlanPage.getElementBackgroundColor(allPointsOnHomePlan.get(i));
+            String expectedSensorOnHomePlanBorderColor = markSensorOnHomePlanPage.sensorBackgroundAndBorderColorMap().get(sensorOnHomePlanBackgroundColor);
+            String expectedCharSequenceInBackgroundColor = markSensorOnHomePlanPage.getSensorTypeBackgroundColor(allConnectedSensors.get(i));
+            System.out.println(actualSensorOnConnectedSensorsListBackgroundColor);
+            Assert.assertEquals(actualSensorOnHomePlanBorderColor, expectedSensorOnHomePlanBorderColor); //Check if selected sensor on home plan has border color of color matching sensor type
+            Assert.assertTrue(actualSensorOnConnectedSensorsListBackgroundColor.contains(expectedCharSequenceInBackgroundColor)); //Check if selected sensor on connected sensors list has background color of color matching sensor type
+        }
     }
 
     @Test
     public void testBorderAndBackgroundColorOfNotSelectedSensorOnHomePlan() {
-        markSensorOnHomePlanPage.clickOnHomePlan(0, 0);  // Select first sensor on home plan
+        markSensorOnHomePlanPage.clickSensorOnHomePlan(markSensorOnHomePlanPage.firstSensorOnHomePlan);  // Select first sensor on home plan
         String actualBorderColor = markSensorOnHomePlanPage.getElementBorderColor(markSensorOnHomePlanPage.secondSensorOnHomePlan);
         String expectedBorderColor = "rgb(0, 0, 0)";
         String actualBackgroundColor = markSensorOnHomePlanPage.getElementBackgroundColor(markSensorOnHomePlanPage.secondSensorOnConnectedSensorsList);
-        String expectedBackgroundColor = "rgba(0, 0, 0, 0)";
-
+        String expectedBackgroundColor = "rgba(255, 255, 255, 1)";
         Assert.assertEquals(actualBorderColor, expectedBorderColor);
         Assert.assertEquals(actualBackgroundColor, expectedBackgroundColor);
     }
@@ -56,7 +52,7 @@ public class MarkSensorOnHomePlanTest extends TestBase {
     public void testScrollAutoToSelectedSensor() throws InterruptedException {
         markSensorOnHomePlanPage.resizeBrowser();
         markSensorOnHomePlanPage.waitUntilHomePlanIsLoaded();
-        WebElement sensor = markSensorOnHomePlanPage.sensorOnConnectedSensorsList;
+        WebElement sensor = markSensorOnHomePlanPage.lastSensorOnConnectedSensorsList;
         Assert.assertFalse(markSensorOnHomePlanPage.isSensorInViewPort(sensor));
         markSensorOnHomePlanPage.clickLastSensorOnHomePlan();
         markSensorOnHomePlanPage.waitForScrollToComplete(sensor);


### PR DESCRIPTION
W związku z tym że endpoint '/api/v1/dashboard/delete' został usunięty przez grupę JS zostały poprawione następujące testy:
AddSensorOnHomePlanTest
DeleteSensorFromHomePlanTest
MapTest
MarkSensorOnHomePlanTest