### PR TITLE
Add NotificationPageTest and cookie for gateway

### DIFF
--- a/src/main/java/selenium/base/TestBase.java
+++ b/src/main/java/selenium/base/TestBase.java
@@ -32,6 +32,7 @@ public class TestBase {
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
         driver.get("https://patronage20-js-master.herokuapp.com");
         driver.manage().addCookie(new Cookie("secret_cookie", "3241231213fsdj23kj4kl32j4"));
+        driver.manage().addCookie(new Cookie("SuperToken", "59c5f5b2cb7ca698b5b9dd199a10914dc6047ef1afe07d2879c89637fef05ae2"));
     }
 
     @AfterTest

--- a/src/main/java/selenium/base/TestCommons.java
+++ b/src/main/java/selenium/base/TestCommons.java
@@ -114,7 +114,7 @@ public abstract class TestCommons {
         } catch (org.openqa.selenium.TimeoutException e) {
             return false;
         } catch (org.openqa.selenium.NoSuchElementException
-                | org.openqa.selenium.StaleElementReferenceException e){
+                | org.openqa.selenium.StaleElementReferenceException e) {
             return true;
         }
     }
@@ -128,9 +128,8 @@ public abstract class TestCommons {
             map.put("upload_throughput", 0);
             CommandExecutor executor = ((ChromeDriver) driver).getCommandExecutor();
             executor.execute(new Command(((ChromeDriver) driver).getSessionId(), "setNetworkConditions",
-                            ImmutableMap.of("network_conditions", ImmutableMap.copyOf(map))));
-        }
-        else {
+                    ImmutableMap.of("network_conditions", ImmutableMap.copyOf(map))));
+        } else {
             Map map = new HashMap();
             map.put("offline", false);
             map.put("latency", 10);
@@ -138,7 +137,7 @@ public abstract class TestCommons {
             map.put("upload_throughput", 1000);
             CommandExecutor executor = ((ChromeDriver) driver).getCommandExecutor();
             executor.execute(new Command(((ChromeDriver) driver).getSessionId(), "setNetworkConditions",
-                            ImmutableMap.of("network_conditions", ImmutableMap.copyOf(map))));
+                    ImmutableMap.of("network_conditions", ImmutableMap.copyOf(map))));
         }
     }
 
@@ -169,18 +168,6 @@ public abstract class TestCommons {
                 }
             }
         });
-    }
-
-    protected static boolean isElementNotDisplayed(WebDriver driver, WebElement element) {
-        try {
-            WebDriverWait wait = new WebDriverWait(driver, 10);
-            wait.until(ExpectedConditions.invisibilityOf(element));
-            return !(element.isDisplayed());
-        } catch (org.openqa.selenium.NoSuchElementException
-                | org.openqa.selenium.StaleElementReferenceException
-                | org.openqa.selenium.TimeoutException e) {
-            return true;
-        }
     }
 }
 

--- a/src/main/java/selenium/pages/NotificationsPage.java
+++ b/src/main/java/selenium/pages/NotificationsPage.java
@@ -1,0 +1,193 @@
+package selenium.pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+import selenium.base.TestCommons;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+public class NotificationsPage extends TestCommons {
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div/div[1]/ul")
+    private WebElement activeNotifications;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div/div[2]/div/ul")
+    private WebElement inactiveNotifications;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div/div[1]/ul/li[1]")
+    public WebElement firstActiveNotification;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div/div[1]/ul/li[1]")
+    public WebElement secondActiveNotification;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div/div[2]/div/ul/div[1]")
+    public WebElement firstInactiveNotification;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div/div[2]/div/ul/div[2]")
+    public WebElement secondInactiveNotification;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div/div[2]/button")
+    private WebElement showMoreButton;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[1]/header/div/div[2]/button/span[1]/span/span")
+    private WebElement activeNotificationsCounter;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[1]/header/div/div[2]/button")
+    private WebElement notificationsButton;
+
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div[2]/ul")
+    private WebElement activeNotificationsInDrawer;
+
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div[2]/ul/li[1]")
+    private WebElement firstNotificationInDrawer;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[1]/header/div/div[1]/div/div/a[3]")
+    private WebElement authorsButton;
+
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div[1]")
+    private WebElement notificationPageLink;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div/h6")
+    private WebElement notificationsHeader;
+
+    public NotificationsPage(WebDriver driver) {
+        super(driver);
+    }
+
+    public void goTo() {
+        goTo("/notifications");
+    }
+
+    public String getDataAndTimeOfNotification(WebElement element) {
+        return (element.findElement(By.tagName("p")).getText());
+    }
+
+    public Date getDateAndTimeFormat(WebElement element) throws ParseException {
+        String sData = getDataAndTimeOfNotification(element);
+        SimpleDateFormat formatter = new SimpleDateFormat("dd.MM.yyyy, HH:mm:ss");
+        Date date = formatter.parse(sData);
+        return date;
+    }
+
+    public Integer compareDateAndTime(WebElement firstNotification, WebElement secondNotification) throws ParseException {
+        return getDateAndTimeFormat(firstNotification).compareTo(getDateAndTimeFormat(secondNotification));
+
+    }
+
+    public Integer getAllActiveNotifications() {
+        int i;
+        if (thereAreActiveNotifications()) {
+            List<WebElement> allActiveNotifications = activeNotifications.findElements(By.tagName("li"));
+            i = allActiveNotifications.size();
+        } else {
+            i = 0;
+        }
+        return i;
+    }
+
+    public Integer getAllActiveNotificationsInDrawer() {
+        int i;
+        if (thereAreNotificationsInDrawer()) {
+            List<WebElement> allActiveNotificationsInDrawer = activeNotificationsInDrawer.findElements(By.tagName("li"));
+            i = allActiveNotificationsInDrawer.size();
+        } else {
+            i = 0;
+        }
+        return i;
+    }
+
+    public Integer getAllInactiveNotifications() {
+        int i;
+        if (thereAreInactiveNotifications()) {
+            List<WebElement> allInactiveNotifications = inactiveNotifications.findElements(By.tagName("p"));
+            i = allInactiveNotifications.size();
+        } else {
+            i = 0;
+        }
+        return i;
+    }
+
+    public boolean thereAreActiveNotifications() {
+        return isElementDisplayed(driver, activeNotifications);
+    }
+
+    public boolean thereAreNotificationsInDrawer() {
+        return isElementDisplayed(driver, activeNotificationsInDrawer);
+    }
+
+    public boolean thereAreInactiveNotifications() {
+        return isElementDisplayed(driver, inactiveNotifications);
+    }
+
+    public boolean showMoreButtonIsDisplayed() {
+        return isElementDisplayed(driver, showMoreButton);
+    }
+
+    public Integer countAllNotificationsOnPage() {
+        int notificationCount = 0;
+        notificationCount = getAllActiveNotifications() + getAllInactiveNotifications();
+        return notificationCount;
+    }
+
+    public void clickShowMoreButton() {
+        clickElement(showMoreButton);
+    }
+
+    public void clickNotificationsButton() {
+        clickElement(notificationsButton);
+    }
+
+    public void clickAuthorsButton() {
+        clickElement(authorsButton);
+    }
+
+    public void clickLinkToNotificationsPage() {
+        clickElement(notificationPageLink);
+    }
+
+    public void deleteActiveNotificationOnPage() {
+        clickElement(firstActiveNotification.findElement(By.tagName("button")));
+    }
+
+    public void deleteNotificationInDrawer() {
+        clickElement(firstNotificationInDrawer.findElement(By.tagName("button")));
+    }
+
+    public Integer getActiveNotificationsFromCounter() {
+        int i;
+        if (thereAreActiveNotifications()) {
+            i = Integer.parseInt(activeNotificationsCounter.getText());
+        } else {
+            i = 0;
+        }
+        return i;
+    }
+
+    public void clickOutsideDrawer(int xOffset, int yOffset) {
+        Actions builder = new Actions(driver);
+        builder.moveByOffset(xOffset, yOffset).click().perform();
+    }
+
+    public void waitForDeletedNotificationInDrawer(String expectedCounter) {
+        if (thereAreNotificationsInDrawer()) {
+            waitForElementAttributeToChange(driver, getAllActiveNotificationsInDrawer().toString(), expectedCounter);
+        }
+    }
+
+    public void waitForDeletedNotificationOnPage(String expectedCounter) {
+        if (thereAreActiveNotifications()) {
+            waitForElementAttributeToChange(driver, getAllActiveNotifications().toString(), expectedCounter);
+        }
+    }
+
+    public boolean notificationsHeaderIsDisplayed() {
+        return isElementDisplayed(driver, notificationsHeader);
+    }
+
+}

--- a/src/test/java/selenium/NotificationsPageTest.java
+++ b/src/test/java/selenium/NotificationsPageTest.java
@@ -1,0 +1,116 @@
+package selenium;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import selenium.base.TestBase;
+import selenium.pages.NotificationsPage;
+
+import java.text.ParseException;
+
+public class NotificationsPageTest extends TestBase {
+    private NotificationsPage notificationsPage;
+
+    @BeforeClass
+    public void beforeClass() {
+        notificationsPage = new NotificationsPage(driver);
+        notificationsPage.goTo();
+    }
+
+    @Test
+    public void pageIsLoaded() {
+        Assert.assertTrue(notificationsPage.notificationsHeaderIsDisplayed(), "Notifications page is not loaded");
+    }
+
+    @Test(dependsOnMethods = {"pageIsLoaded"})
+    public void testNotificationsAreDisplayedByTimestamp() throws ParseException {
+        if ((notificationsPage.thereAreActiveNotifications()) && (notificationsPage.getAllActiveNotifications() >= 2)) {
+            int timestamp = notificationsPage.compareDateAndTime(notificationsPage.firstActiveNotification, notificationsPage.secondActiveNotification);
+            Assert.assertTrue(timestamp >= 0, "Active notifications are not displayed in order by date and time");
+        }
+        if ((notificationsPage.thereAreInactiveNotifications()) && (notificationsPage.getAllInactiveNotifications() >= 2)) {
+            int timestamp = notificationsPage.compareDateAndTime(notificationsPage.firstInactiveNotification, notificationsPage.secondInactiveNotification);
+            Assert.assertTrue(timestamp >= 0, "Inactive notifications are not displayed in order by date and time");
+        }
+    }
+
+    @Test(dependsOnMethods = {"pageIsLoaded"})
+    public void testPagination() {
+        int notificationsCount = notificationsPage.countAllNotificationsOnPage();
+        Assert.assertTrue(notificationsCount <= 20, "There are more than 20 notifications on first page");
+        if (notificationsCount == 20) {
+            if (notificationsPage.showMoreButtonIsDisplayed()) {
+                notificationsPage.clickShowMoreButton();
+                Assert.assertTrue(notificationsPage.countAllNotificationsOnPage() > 20, "There are less than 20 notifications on second page");
+                Assert.assertTrue(notificationsPage.countAllNotificationsOnPage() <= 40, "There are more than 40 notifications on second page");
+            }
+        }
+    }
+
+    @Test(dependsOnMethods = {"pageIsLoaded"})
+    public void testAccessToPageByLink() {
+        notificationsPage.clickAuthorsButton();
+        notificationsPage.clickNotificationsButton();
+        notificationsPage.clickLinkToNotificationsPage();
+        notificationsPage.clickOutsideDrawer(100, 100);
+        String expectedUrl = "https://patronage20-js-master.herokuapp.com/notifications";
+        String actualUrl = driver.getCurrentUrl();
+        Assert.assertEquals(actualUrl, expectedUrl, "No access to notification page by link in drawer");
+
+    }
+
+    @Test(dependsOnMethods = {"pageIsLoaded"})
+    public void testIntegrationOfNotificationPageWithCounterAndDrawer() {
+        int notificationsOnPage = notificationsPage.getAllActiveNotifications();
+        int notificationsInCounter = notificationsPage.getActiveNotificationsFromCounter();
+        notificationsPage.clickNotificationsButton();
+        int notificationsInDrawer = notificationsPage.getAllActiveNotificationsInDrawer();
+
+        Assert.assertEquals(notificationsOnPage, notificationsInDrawer, "Initial count on page and in drawer is not matching");
+        Assert.assertEquals(notificationsOnPage, notificationsInCounter, "Initial count on page and in counter is not matching");
+
+        notificationsPage.clickOutsideDrawer(100, 100);
+
+        int notificationsOnPageAfterChangeOnPage;
+        int notificationsInDrawerAfterChangeOnPage;
+        int notificationsInCounterAfterChangeOnPage = 0;
+
+        if (notificationsInCounter > 0) {
+            notificationsPage.deleteActiveNotificationOnPage();
+            String expectedCounter = Integer.toString(notificationsInCounter - 1);
+            notificationsPage.waitForDeletedNotificationOnPage(expectedCounter);
+            notificationsPage.clickNotificationsButton();
+            notificationsPage.waitForDeletedNotificationInDrawer(expectedCounter);
+            notificationsInDrawerAfterChangeOnPage = notificationsPage.getAllActiveNotificationsInDrawer();
+            notificationsPage.clickOutsideDrawer(100, 100);
+            notificationsOnPageAfterChangeOnPage = notificationsPage.getAllActiveNotifications();
+            notificationsInCounterAfterChangeOnPage = notificationsPage.getActiveNotificationsFromCounter();
+
+            Assert.assertEquals(notificationsOnPageAfterChangeOnPage, notificationsOnPage - 1, "Incorrect count on page");
+            Assert.assertEquals(notificationsInDrawerAfterChangeOnPage, notificationsInDrawer - 1, "Incorrect count in drawer");
+            Assert.assertEquals(notificationsInCounterAfterChangeOnPage, notificationsInCounter - 1, "Incorrect count in counter");
+        }
+
+        int notificationsOnPageAfterChangeInDrawer;
+        int notificationsInDrawerAfterChangeInDrawer;
+        int notificationsInCounterAfterChangeInDrawer;
+
+        if (notificationsInCounterAfterChangeOnPage > 0) {
+            notificationsPage.clickNotificationsButton();
+            notificationsPage.deleteNotificationInDrawer();
+            String expectedCounter = Integer.toString(notificationsInCounterAfterChangeOnPage - 1);
+            notificationsPage.waitForDeletedNotificationInDrawer(expectedCounter);
+            notificationsPage.clickOutsideDrawer(100, 100);
+            notificationsPage.waitForDeletedNotificationOnPage(expectedCounter);
+            notificationsOnPageAfterChangeInDrawer = notificationsPage.getAllActiveNotifications();
+            notificationsInCounterAfterChangeInDrawer = notificationsPage.getActiveNotificationsFromCounter();
+            notificationsPage.clickNotificationsButton();
+            notificationsInDrawerAfterChangeInDrawer = notificationsPage.getAllActiveNotificationsInDrawer();
+            notificationsPage.clickOutsideDrawer(100, 100);
+
+            Assert.assertEquals(notificationsOnPageAfterChangeInDrawer, notificationsOnPage - 2, "Incorrect count on page");
+            Assert.assertEquals(notificationsInDrawerAfterChangeInDrawer, notificationsInDrawer - 2, "Incorrect count in drawer");
+            Assert.assertEquals(notificationsInCounterAfterChangeInDrawer, notificationsInCounter - 2, "Incorrect count in counter");
+        }
+    }
+}

--- a/suites/notificationsPageTest.xml
+++ b/suites/notificationsPageTest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Notifications page test suite">
+    <test name="Notifications page test">
+        <classes>
+            <class name="selenium.NotificationsPageTest"></class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Test działa na tym co jest czyli na 2 notyfikacjach ale przygotowany jest na ich większą ilość. W celu odświeżenia notyfikacji, gdybyś chciał sprawdzić jak test działa przy aktywnych notyfikacjach, należy posłużyć się: 'https://patronage20-js-master.herokuapp.com/api/v1/notifications/delete' przed uruchomieniem testu. To jest rozwiązanie developerskie i tym razem już nie użyłam tego w teście.