### PR TITLE
Wip language versions

### DIFF
--- a/src/main/java/selenium/base/TestBase.java
+++ b/src/main/java/selenium/base/TestBase.java
@@ -4,6 +4,7 @@ import org.openqa.selenium.Cookie;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.testng.ITestContext;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.BeforeTest;
@@ -21,9 +22,13 @@ public class TestBase {
     }
 
     @BeforeTest
-    public void setUp() {
+    public void setUp (ITestContext context) {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--incognito");
+        String language = context.getCurrentXmlTest().getParameter("browserLanguage");
+        if(language!=null) {
+            options.addArguments("--lang=" + language);
+        }
         driver = new ChromeDriver(options);
         driver.manage().window().maximize();
         driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);

--- a/src/main/java/selenium/pages/LanguageDashboardPage.java
+++ b/src/main/java/selenium/pages/LanguageDashboardPage.java
@@ -18,21 +18,21 @@ public class LanguageDashboardPage extends TestCommons {
     @FindBy(xpath = "/html/body/div[2]/div[3]/ul/li[2]")
     public WebElement plLanguageLabel;
     @FindBy(xpath = "/html/body/div[1]/div/div[1]/header/div/h6")
-    public WebElement title;
+    private WebElement title;
     @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[1]/span[1]")
-    public WebElement mainPanelTile;
+    private WebElement mainPanelTile;
     @FindBy(xpath =  "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[2]/span[1]")
-    public WebElement hvacTile;
+    private WebElement hvacTile;
     @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[3]/span[1]")
-    public WebElement authorsTile;
+    private WebElement authorsTile;
     @FindBy(xpath = "/html/body/div/div/div[3]/div[1]/div/div/div/div")
-    public WebElement snackBar;
+    private WebElement snackBar;
     @FindBy(xpath = "/html/body/div/div/div[3]/div[2]/div/div/div/div")
-    public WebElement snackBar2;
+    private WebElement snackBar2;
     @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]")
-    public WebElement inactiveList;
+    private WebElement inactiveList;
     @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[2]")
-    public WebElement activeList;
+    private WebElement activeList;
     @FindBy(xpath = "/html/body/div/div/div[2]/div/h2/div")
     public WebElement loadMapSnackBar;
     @FindBy(xpath = "/html/body/div/div/div[2]/div/button")
@@ -41,7 +41,7 @@ public class LanguageDashboardPage extends TestCommons {
     public WebElement sensor1;
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
     public WebElement homePlan;
-    
+
 //    @FindBy(xpath = "/html/body/div/div/div[3]/div[3]/div/div/div")
 //    public WebElement sensorAddSnackbar;
 //    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/li")
@@ -59,6 +59,11 @@ public class LanguageDashboardPage extends TestCommons {
         return listOfSensorsTextsPl;
     }
 
+    @Override
+    public void clickElement(WebElement element) {
+        super.clickElement(element);
+    }
+
     public List<String> getSensorStringsEn(){
         listOfSensorsTextsEn.add(inactiveList.getText());
         listOfSensorsTextsEn.add(activeList.getText());
@@ -67,11 +72,6 @@ public class LanguageDashboardPage extends TestCommons {
 
     public String getElementTranslations(WebElement element){
         return element.getText();
-    }
-
-    @Override
-    public void clickElement(WebElement element) {
-        super.clickElement(element);
     }
 
     public LanguageDashboardPage(WebDriver driver) {

--- a/src/main/java/selenium/pages/LanguageDashboardPage.java
+++ b/src/main/java/selenium/pages/LanguageDashboardPage.java
@@ -1,0 +1,159 @@
+package selenium.pages;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.FindBy;
+import org.testng.Assert;
+import selenium.base.TestCommons;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LanguageDashboardPage extends TestCommons {
+
+    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[2]/div/div/div")
+    public WebElement languageLabel;
+    @FindBy(css = "#menu- > div.MuiPaper-root.MuiMenu-paper.MuiPopover-paper.MuiPaper-elevation8.MuiPaper-rounded > ul > li:nth-child(1)")
+    public WebElement enLanguageLabel;
+    @FindBy(xpath = "/html/body/div[2]/div[3]/ul/li[2]")
+    public WebElement plLanguageLabel;
+    @FindBy(xpath = "/html/body/div[1]/div/div[1]/header/div/h6")
+    public WebElement title;
+    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[1]/span[1]")
+    public WebElement mainPanelTile;
+    @FindBy(xpath =  "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[2]/span[1]")
+    public WebElement hvacTile;
+    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[3]/span[1]")
+    public WebElement authorsTile;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/li")
+    public WebElement notPlacedSensorsTitle;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[2]/li")
+    public WebElement placedSensorsTitle;
+    @FindBy(xpath = "/html/body/div/div/div[3]/div[1]/div/div/div/div")
+    public WebElement snackBar;
+    @FindBy(xpath = "/html/body/div/div/div[3]/div[2]/div/div/div/div")
+    public WebElement snackBar2;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]")
+    public WebElement inactiveList;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[2]")
+    public WebElement activeList;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/h2/div")
+    public WebElement loadMapSnackBar;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/button")
+    public WebElement refreshButton;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[1]")
+    public WebElement sensor1;
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
+    public WebElement homePlan;
+    @FindBy(xpath = "/html/body/div/div/div[3]/div[3]/div/div/div")
+    public WebElement sensorAddSnackbar;
+
+
+    ArrayList<String> listOfSensorsTextsPl = new ArrayList<>();
+    ArrayList<String> listOfSensorsTextsEn = new ArrayList<>();
+    ArrayList<String> listOfExpectedSensorsTextsPl = new ArrayList<>();
+
+    public ArrayList<String> getSensorStringsPl(){
+        listOfSensorsTextsPl.add(inactiveList.getText());
+        listOfSensorsTextsPl.add(activeList.getText());
+        return listOfSensorsTextsPl;
+    }
+
+
+    public List<String> getSensorStringsEn(){
+        listOfSensorsTextsEn.add(inactiveList.getText());
+        listOfSensorsTextsEn.add(activeList.getText());
+        return listOfSensorsTextsEn;
+    }
+
+    public String getElementTranslations(WebElement element){
+        return element.getText();
+    }
+
+    @Override
+    public void clickElement(WebElement element) {
+        super.clickElement(element);
+    }
+
+    public LanguageDashboardPage(WebDriver driver) {
+        super(driver);
+    }
+
+    public void goTo() {
+        goTo("/");
+    }
+
+    public void waitingForLanguageLabelVisibility()
+    {
+        isElementDisplayed(driver, languageLabel, 5);
+    }
+
+    public void verifyPlTranslation(){
+        Assert.assertEquals(getElementTranslations(languageLabel), "PL", "Domyślny język nie jest zgodny z językiem przeglądarki (polski)");
+        Assert.assertEquals(getElementTranslations(title), "Smart Home", "Niepoprawne tłumaczenie tytułu strony");
+        Assert.assertEquals(getElementTranslations(mainPanelTile), "PANEL GŁÓWNY", "Niepoprawne tłumaczenie zakładki DASHBOARD");
+        Assert.assertEquals(getElementTranslations(hvacTile), "HVAC", "Niepoprawne tłumaczenie zakładki HVAC");
+        Assert.assertEquals(getElementTranslations(authorsTile), "AUTORZY", "Niepoprawne tłumaczenie zakładki AUTHORS");
+    }
+
+    public void verifyEnTranslation(){
+        Assert.assertEquals(getElementTranslations(languageLabel), "EN", "Domyslny język nie jest językiem angielskim");
+        Assert.assertEquals(getElementTranslations(title), "Smart Home", "Niepoprawne tłumaczenie tytułu strony");
+        Assert.assertEquals(getElementTranslations(mainPanelTile), "DASHBOARD", "Niepoprawne tłumaczenie zakładki Panel główny");
+        Assert.assertEquals(getElementTranslations(hvacTile), "HVAC", "Niepoprawne tłumaczenie zakładki HVAC");
+        Assert.assertEquals(getElementTranslations(authorsTile), "AUTHORS", "Niepoprawne tłumaczenie zakładki Autorzy");
+    }
+
+    public void verifySnackbarsPl(){
+        snackBarExist(snackBar, 10);
+        snackBarExist(snackBar2, 10);
+        Assert.assertEquals(getElementTranslations(snackBar2), "Odświeżenie stanu czujników nie powiodło się.");
+        Assert.assertEquals(getElementTranslations(snackBar), "Hej, coś nie styka! Sprawdź połączenie.");
+    }
+
+    public void verifySnackbarsPlAfterLanguageChange(){
+        snackBarExist(snackBar, 10);
+        snackBarExist(snackBar2, 10);
+        Assert.assertEquals(getElementTranslations(snackBar), "Odświeżenie stanu czujników nie powiodło się.");
+        Assert.assertEquals(getElementTranslations(snackBar2), "Hej, coś nie styka! Sprawdź połączenie.");
+    }
+
+    public void verifySnackbarsEn(){
+        snackBarExist(snackBar, 10);
+        snackBarExist(snackBar2, 10);
+        Assert.assertEquals(getElementTranslations(snackBar2), "Could not refresh sensors' status.");
+        Assert.assertEquals(getElementTranslations(snackBar), "Hey, something isn't quite right! Check your connection.");
+    }
+
+    public void verifyLoadMapPl(String loadMapSnackBar,String refreshButton){
+        Assert.assertEquals(loadMapSnackBar, "Coś poszło nie tak....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home PL.");
+        Assert.assertEquals(refreshButton, "ODŚWIEŻ", "Nieprawidłowa nazwa przycisku odświeżania PL.");
+    }
+    public void verifyLoadMapEn(String loadMapSnackBar,String refreshButton){
+        Assert.assertEquals(loadMapSnackBar, "Something went wrong....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home EN.");
+        Assert.assertEquals(refreshButton, "REFRESH", "Nieprawidłowa nazwa przycisku odświeżania EN.");
+    }
+    public void verifySensorAddSnackbarPl(String sensorAddSnackbarPl){
+        Assert.assertEquals(sensorAddSnackbarPl, "Czujnik 61 nie został dodany." );
+    }
+    public void verifySensorAddSnackbarEn(String sensorAddSnackbarEn){
+        Assert.assertEquals(sensorAddSnackbarEn, "Sensor 61 could not be added." );
+    }
+
+
+    public boolean snackBarExist(WebElement webElement, int time) {
+        if (isElementDisplayed(driver, webElement, time)==true) {
+            return true;
+        }
+        return false;
+    }
+
+    public void clickToAddPoint(int xOffset, int yOffset) {
+        Actions builder = new Actions(driver);
+        builder.moveToElement(homePlan, xOffset, yOffset).click().perform();
+    }
+
+    public void polishSensorsNames(){
+
+    }
+}

--- a/src/main/java/selenium/pages/LanguageDashboardPage.java
+++ b/src/main/java/selenium/pages/LanguageDashboardPage.java
@@ -7,72 +7,69 @@ import org.openqa.selenium.support.FindBy;
 import org.testng.Assert;
 import org.testng.asserts.SoftAssert;
 import selenium.base.TestCommons;
-import java.util.ArrayList;
-import java.util.List;
 
 public class LanguageDashboardPage extends TestCommons {
 
-
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/h2/div")
-    public WebElement loadMapSnackBar;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/button")
-    public WebElement refreshButton;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[1]/div/div[1]/div")
-    public WebElement sensor1;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[2]/div/div[1]/div")
-    public WebElement sensor2;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[3]/div/div[1]/div")
-    public WebElement sensor3;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[4]/div/div[1]/div")
-    public WebElement sensor4;
-    @FindBy(xpath = "/html/body/div[2]/div[3]/div/div[3]/button")
-    public WebElement sensorProximityWarningExitButton;
-    @FindBy(xpath = "/html/body/div[2]/div[3]/div")
-    private WebElement sensorProximityWarning;
-    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[2]/div/div/div")
-    private WebElement languageLabel;
-    @FindBy(css = "#menu- > div.MuiPaper-root.MuiMenu-paper.MuiPopover-paper.MuiPaper-elevation8.MuiPaper-rounded > ul > li:nth-child(1)")
-    private WebElement enLanguageLabel;
-    @FindBy(xpath = "/html/body/div[2]/div[3]/ul/li[2]")
-    private WebElement plLanguageLabel;
-    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
-    private WebElement homePlan;
-    @FindBy(xpath = "/html/body/div[1]/div/div[1]/header/div/h6")
-    private WebElement title;
-    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[1]/span[1]")
-    private WebElement mainPanelTile;
-    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[2]/span[1]")
-    private WebElement hvacTile;
     @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[3]/span[1]")
     private WebElement authorsTile;
+
+    @FindBy(css = "#menu- > div.MuiPaper-root.MuiMenu-paper.MuiPopover-paper.MuiPaper-elevation8.MuiPaper-rounded > ul > li:nth-child(1)")
+    private WebElement enLanguageLabel;
+
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
+    private WebElement homePlan;
+
+    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[2]/span[1]")
+    private WebElement hvacTile;
+
+    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[2]/div/div/div")
+    private WebElement languageLabel;
+
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/h2/div")
+    private WebElement loadMapSnackBar;
+
+    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[1]/span[1]")
+    private WebElement mainPanelTile;
+
+    @FindBy(xpath = "/html/body/div[2]/div[3]/ul/li[2]")
+    private WebElement plLanguageLabel;
+
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/button")
+    private WebElement refreshButton;
+
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[1]/div/div[1]/div")
+    private WebElement sensor1;
+
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[2]/div/div[1]/div")
+    private WebElement sensor2;
+
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[3]/div/div[1]/div")
+    private WebElement sensor3;
+
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[4]/div/div[1]/div")
+    private WebElement sensor4;
+
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div")
+    private WebElement sensorProximityWarning;
+
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div/div[3]/button")
+    private WebElement sensorProximityWarningExitButton;
+
     @FindBy(xpath = "/html/body/div/div/div[3]/div[1]/div/div/div/div")
     private WebElement snackBar;
+
     @FindBy(xpath = "/html/body/div/div/div[3]/div[2]/div/div/div/div")
     private WebElement snackBar2;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]")
-    private WebElement inactiveList;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[2]")
-    private WebElement activeList;
-//    --------------------
-    @Override
-    public void clickElement(WebElement element) {
-        super.clickElement(element);
-    }
-//    --------------------
+
+    @FindBy(xpath = "/html/body/div[1]/div/div[1]/header/div/h6")
+    private WebElement title;
+
     public LanguageDashboardPage(WebDriver driver) {
         super(driver);
     }
 
     public void goTo() {
         goTo("/");
-    }
-
-    public void verifyChosenLanguagePl (){
-        Assert.assertEquals(getElementTranslations(languageLabel), "PL", "Przeglądarka nie jest odpalona w języku polskim.");
-    }
-
-    public void verifyChosenLanguageEn(){
-        Assert.assertEquals(getElementTranslations(languageLabel), "EN", "Język angielski nie jest językiem domyślnym.");
     }
 
     public String getElementTranslations(WebElement element) {
@@ -89,6 +86,26 @@ public class LanguageDashboardPage extends TestCommons {
 
     public boolean snackBarExists(WebElement webElement, int time) {
         return isElementDisplayed(driver, webElement, time);
+    }
+
+    public void clickSensor1(){
+        clickElement(sensor1);
+    }
+
+    public void clickSensor2(){
+        clickElement(sensor2);
+    }
+
+    public void clickSensor3(){
+        clickElement(sensor3);
+    }
+
+    public void clickSensor4(){
+        clickElement(sensor4);
+    }
+
+    public void clickSensorProximityWarningExitButton(){
+        clickElement(sensorProximityWarningExitButton);
     }
 
     public void clickToAddPoint(int xOffset, int yOffset) {
@@ -111,7 +128,6 @@ public class LanguageDashboardPage extends TestCommons {
         appendTotalAssert.assertEquals(getElementTranslations(mainPanelTile), "PANEL GŁÓWNY", "Niepoprawne tłumaczenie zakładki DASHBOARD");
         appendTotalAssert.assertEquals(getElementTranslations(hvacTile), "HVAC", "Niepoprawne tłumaczenie zakładki HVAC");
         appendTotalAssert.assertEquals(getElementTranslations(authorsTile), "AUTORZY", "Niepoprawne tłumaczenie zakładki AUTHORS");
-        appendTotalAssert.assertEquals(getElementTranslations(title), "Smart Home", "Nazwa aplikacji nie powinna być tłumaczona.");
     }
 
     public void verifyEnTranslation(SoftAssert appendTotalAssert) {
@@ -120,7 +136,6 @@ public class LanguageDashboardPage extends TestCommons {
         appendTotalAssert.assertEquals(getElementTranslations(mainPanelTile), "DASHBOARD", "Niepoprawne tłumaczenie zakładki Panel główny");
         appendTotalAssert.assertEquals(getElementTranslations(hvacTile), "HVAC", "Niepoprawne tłumaczenie zakładki HVAC");
         appendTotalAssert.assertEquals(getElementTranslations(authorsTile), "AUTHORS", "Niepoprawne tłumaczenie zakładki Autorzy");
-        appendTotalAssert.assertEquals(getElementTranslations(title), "Smart Home", "Nazwa aplikacji nie powinna być tłumaczona.");
     }
 
     public void verifySnackbarsPl(SoftAssert appendTotalAssert) {
@@ -144,14 +159,14 @@ public class LanguageDashboardPage extends TestCommons {
         appendTotalAssert.assertEquals(getElementTranslations(snackBar), "Hey, something isn't quite right! Check your connection.");
     }
 
-    public void verifyLoadMapPl(SoftAssert appendTotalAssert, String loadMapSnackBar, String refreshButton) {
-        appendTotalAssert.assertEquals(loadMapSnackBar, "Coś poszło nie tak....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home PL.");
-        appendTotalAssert.assertEquals(refreshButton, "ODŚWIEŻ", "Nieprawidłowa nazwa przycisku odświeżania PL.");
+    public void verifyLoadMapPl(SoftAssert appendTotalAssert) {
+        appendTotalAssert.assertEquals(getElementTranslations(loadMapSnackBar), "Coś poszło nie tak....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home PL.");
+        appendTotalAssert.assertEquals(getElementTranslations(refreshButton), "ODŚWIEŻ", "Nieprawidłowa nazwa przycisku odświeżania PL.");
     }
 
-    public void verifyLoadMapEn(SoftAssert appendTotalAssert, String loadMapSnackBar, String refreshButton) {
-        appendTotalAssert.assertEquals(loadMapSnackBar, "Something went wrong....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home EN.");
-        appendTotalAssert.assertEquals(refreshButton, "REFRESH", "Nieprawidłowa nazwa przycisku odświeżania EN.");
+    public void verifyLoadMapEn(SoftAssert appendTotalAssert) {
+        appendTotalAssert.assertEquals(getElementTranslations(loadMapSnackBar), "Something went wrong....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home EN.");
+        appendTotalAssert.assertEquals(getElementTranslations(refreshButton), "REFRESH", "Nieprawidłowa nazwa przycisku odświeżania EN.");
     }
 
     public void verifyProximityWarningPl(){
@@ -160,5 +175,13 @@ public class LanguageDashboardPage extends TestCommons {
 
     public void verifyProximityWarningEn(){
         Assert.assertEquals(getElementTranslations(sensorProximityWarning), "Gap needed!\n" + "Leave a gap between sensors, please.\n" + "CLOSE", "Niepoprawne ostrzeżenie o zbyt bliskim umiejscowieniu sensorów po angielsku.");
+    }
+
+    public void verifyChosenLanguagePl (){
+        Assert.assertEquals(getElementTranslations(languageLabel), "PL", "Przeglądarka nie jest odpalona w języku polskim.");
+    }
+
+    public void verifyChosenLanguageEn(){
+        Assert.assertEquals(getElementTranslations(languageLabel), "EN", "Język angielski nie jest językiem domyślnym.");
     }
 }

--- a/src/main/java/selenium/pages/LanguageDashboardPage.java
+++ b/src/main/java/selenium/pages/LanguageDashboardPage.java
@@ -25,10 +25,6 @@ public class LanguageDashboardPage extends TestCommons {
     public WebElement hvacTile;
     @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[3]/span[1]")
     public WebElement authorsTile;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/li")
-    public WebElement notPlacedSensorsTitle;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[2]/li")
-    public WebElement placedSensorsTitle;
     @FindBy(xpath = "/html/body/div/div/div[3]/div[1]/div/div/div/div")
     public WebElement snackBar;
     @FindBy(xpath = "/html/body/div/div/div[3]/div[2]/div/div/div/div")
@@ -45,20 +41,23 @@ public class LanguageDashboardPage extends TestCommons {
     public WebElement sensor1;
     @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
     public WebElement homePlan;
-    @FindBy(xpath = "/html/body/div/div/div[3]/div[3]/div/div/div")
-    public WebElement sensorAddSnackbar;
-
+    
+//    @FindBy(xpath = "/html/body/div/div/div[3]/div[3]/div/div/div")
+//    public WebElement sensorAddSnackbar;
+//    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/li")
+//    public WebElement notPlacedSensorsTitle;
+//    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[2]/li")
+//    public WebElement placedSensorsTitle;
 
     ArrayList<String> listOfSensorsTextsPl = new ArrayList<>();
     ArrayList<String> listOfSensorsTextsEn = new ArrayList<>();
-    ArrayList<String> listOfExpectedSensorsTextsPl = new ArrayList<>();
+//    ArrayList<String> listOfExpectedSensorsTextsPl = new ArrayList<>();
 
     public ArrayList<String> getSensorStringsPl(){
         listOfSensorsTextsPl.add(inactiveList.getText());
         listOfSensorsTextsPl.add(activeList.getText());
         return listOfSensorsTextsPl;
     }
-
 
     public List<String> getSensorStringsEn(){
         listOfSensorsTextsEn.add(inactiveList.getText());
@@ -133,6 +132,7 @@ public class LanguageDashboardPage extends TestCommons {
         Assert.assertEquals(loadMapSnackBar, "Something went wrong....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home EN.");
         Assert.assertEquals(refreshButton, "REFRESH", "Nieprawidłowa nazwa przycisku odświeżania EN.");
     }
+//    dla uzycia w przyszlosci
     public void verifySensorAddSnackbarPl(String sensorAddSnackbarPl){
         Assert.assertEquals(sensorAddSnackbarPl, "Czujnik 61 nie został dodany." );
     }
@@ -140,20 +140,16 @@ public class LanguageDashboardPage extends TestCommons {
         Assert.assertEquals(sensorAddSnackbarEn, "Sensor 61 could not be added." );
     }
 
+    public boolean mapLoaded(WebElement webElement, int time){
+       return isElementDisplayed(driver, webElement, time);
+    }
 
     public boolean snackBarExist(WebElement webElement, int time) {
-        if (isElementDisplayed(driver, webElement, time)==true) {
-            return true;
-        }
-        return false;
+        return isElementDisplayed(driver, webElement, time);
     }
 
     public void clickToAddPoint(int xOffset, int yOffset) {
         Actions builder = new Actions(driver);
         builder.moveToElement(homePlan, xOffset, yOffset).click().perform();
-    }
-
-    public void polishSensorsNames(){
-
     }
 }

--- a/src/main/java/selenium/pages/LanguageDashboardPage.java
+++ b/src/main/java/selenium/pages/LanguageDashboardPage.java
@@ -5,23 +5,43 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 import org.testng.Assert;
+import org.testng.asserts.SoftAssert;
 import selenium.base.TestCommons;
 import java.util.ArrayList;
 import java.util.List;
 
 public class LanguageDashboardPage extends TestCommons {
 
+
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/h2/div")
+    public WebElement loadMapSnackBar;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/button")
+    public WebElement refreshButton;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[1]/div/div[1]/div")
+    public WebElement sensor1;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[2]/div/div[1]/div")
+    public WebElement sensor2;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[3]/div/div[1]/div")
+    public WebElement sensor3;
+    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[4]/div/div[1]/div")
+    public WebElement sensor4;
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div/div[3]/button")
+    public WebElement sensorProximityWarningExitButton;
+    @FindBy(xpath = "/html/body/div[2]/div[3]/div")
+    private WebElement sensorProximityWarning;
     @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[2]/div/div/div")
-    public WebElement languageLabel;
+    private WebElement languageLabel;
     @FindBy(css = "#menu- > div.MuiPaper-root.MuiMenu-paper.MuiPopover-paper.MuiPaper-elevation8.MuiPaper-rounded > ul > li:nth-child(1)")
-    public WebElement enLanguageLabel;
+    private WebElement enLanguageLabel;
     @FindBy(xpath = "/html/body/div[2]/div[3]/ul/li[2]")
-    public WebElement plLanguageLabel;
+    private WebElement plLanguageLabel;
+    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
+    private WebElement homePlan;
     @FindBy(xpath = "/html/body/div[1]/div/div[1]/header/div/h6")
     private WebElement title;
     @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[1]/span[1]")
     private WebElement mainPanelTile;
-    @FindBy(xpath =  "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[2]/span[1]")
+    @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[2]/span[1]")
     private WebElement hvacTile;
     @FindBy(xpath = "/html/body/div/div/div[1]/header/div/div[1]/div/div/a[3]/span[1]")
     private WebElement authorsTile;
@@ -33,47 +53,12 @@ public class LanguageDashboardPage extends TestCommons {
     private WebElement inactiveList;
     @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[2]")
     private WebElement activeList;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/h2/div")
-    public WebElement loadMapSnackBar;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/button")
-    public WebElement refreshButton;
-    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/div[1]")
-    public WebElement sensor1;
-    @FindBy(xpath = "//*[@id=\"root\"]/div/div[2]/div/div[1]/div/div/img")
-    public WebElement homePlan;
-
-//    @FindBy(xpath = "/html/body/div/div/div[3]/div[3]/div/div/div")
-//    public WebElement sensorAddSnackbar;
-//    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[1]/li")
-//    public WebElement notPlacedSensorsTitle;
-//    @FindBy(xpath = "/html/body/div/div/div[2]/div/div[2]/ul[2]/li")
-//    public WebElement placedSensorsTitle;
-
-    ArrayList<String> listOfSensorsTextsPl = new ArrayList<>();
-    ArrayList<String> listOfSensorsTextsEn = new ArrayList<>();
-//    ArrayList<String> listOfExpectedSensorsTextsPl = new ArrayList<>();
-
-    public ArrayList<String> getSensorStringsPl(){
-        listOfSensorsTextsPl.add(inactiveList.getText());
-        listOfSensorsTextsPl.add(activeList.getText());
-        return listOfSensorsTextsPl;
-    }
-
+//    --------------------
     @Override
     public void clickElement(WebElement element) {
         super.clickElement(element);
     }
-
-    public List<String> getSensorStringsEn(){
-        listOfSensorsTextsEn.add(inactiveList.getText());
-        listOfSensorsTextsEn.add(activeList.getText());
-        return listOfSensorsTextsEn;
-    }
-
-    public String getElementTranslations(WebElement element){
-        return element.getText();
-    }
-
+//    --------------------
     public LanguageDashboardPage(WebDriver driver) {
         super(driver);
     }
@@ -82,74 +67,98 @@ public class LanguageDashboardPage extends TestCommons {
         goTo("/");
     }
 
-    public void waitingForLanguageLabelVisibility()
-    {
+    public void verifyChosenLanguagePl (){
+        Assert.assertEquals(getElementTranslations(languageLabel), "PL", "Przeglądarka nie jest odpalona w języku polskim.");
+    }
+
+    public void verifyChosenLanguageEn(){
+        Assert.assertEquals(getElementTranslations(languageLabel), "EN", "Język angielski nie jest językiem domyślnym.");
+    }
+
+    public String getElementTranslations(WebElement element) {
+        return element.getText();
+    }
+
+    public void languageLabelExists() {
         isElementDisplayed(driver, languageLabel, 5);
     }
 
-    public void verifyPlTranslation(){
-        Assert.assertEquals(getElementTranslations(languageLabel), "PL", "Domyślny język nie jest zgodny z językiem przeglądarki (polski)");
-        Assert.assertEquals(getElementTranslations(title), "Smart Home", "Niepoprawne tłumaczenie tytułu strony");
-        Assert.assertEquals(getElementTranslations(mainPanelTile), "PANEL GŁÓWNY", "Niepoprawne tłumaczenie zakładki DASHBOARD");
-        Assert.assertEquals(getElementTranslations(hvacTile), "HVAC", "Niepoprawne tłumaczenie zakładki HVAC");
-        Assert.assertEquals(getElementTranslations(authorsTile), "AUTORZY", "Niepoprawne tłumaczenie zakładki AUTHORS");
+    public void mapExists() {
+        isElementDisplayed(driver, homePlan, 5);
     }
 
-    public void verifyEnTranslation(){
-        Assert.assertEquals(getElementTranslations(languageLabel), "EN", "Domyslny język nie jest językiem angielskim");
-        Assert.assertEquals(getElementTranslations(title), "Smart Home", "Niepoprawne tłumaczenie tytułu strony");
-        Assert.assertEquals(getElementTranslations(mainPanelTile), "DASHBOARD", "Niepoprawne tłumaczenie zakładki Panel główny");
-        Assert.assertEquals(getElementTranslations(hvacTile), "HVAC", "Niepoprawne tłumaczenie zakładki HVAC");
-        Assert.assertEquals(getElementTranslations(authorsTile), "AUTHORS", "Niepoprawne tłumaczenie zakładki Autorzy");
-    }
-
-    public void verifySnackbarsPl(){
-        snackBarExist(snackBar, 10);
-        snackBarExist(snackBar2, 10);
-        Assert.assertEquals(getElementTranslations(snackBar2), "Odświeżenie stanu czujników nie powiodło się.");
-        Assert.assertEquals(getElementTranslations(snackBar), "Hej, coś nie styka! Sprawdź połączenie.");
-    }
-
-    public void verifySnackbarsPlAfterLanguageChange(){
-        snackBarExist(snackBar, 10);
-        snackBarExist(snackBar2, 10);
-        Assert.assertEquals(getElementTranslations(snackBar), "Odświeżenie stanu czujników nie powiodło się.");
-        Assert.assertEquals(getElementTranslations(snackBar2), "Hej, coś nie styka! Sprawdź połączenie.");
-    }
-
-    public void verifySnackbarsEn(){
-        snackBarExist(snackBar, 10);
-        snackBarExist(snackBar2, 10);
-        Assert.assertEquals(getElementTranslations(snackBar2), "Could not refresh sensors' status.");
-        Assert.assertEquals(getElementTranslations(snackBar), "Hey, something isn't quite right! Check your connection.");
-    }
-
-    public void verifyLoadMapPl(String loadMapSnackBar,String refreshButton){
-        Assert.assertEquals(loadMapSnackBar, "Coś poszło nie tak....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home PL.");
-        Assert.assertEquals(refreshButton, "ODŚWIEŻ", "Nieprawidłowa nazwa przycisku odświeżania PL.");
-    }
-    public void verifyLoadMapEn(String loadMapSnackBar,String refreshButton){
-        Assert.assertEquals(loadMapSnackBar, "Something went wrong....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home EN.");
-        Assert.assertEquals(refreshButton, "REFRESH", "Nieprawidłowa nazwa przycisku odświeżania EN.");
-    }
-//    dla uzycia w przyszlosci
-    public void verifySensorAddSnackbarPl(String sensorAddSnackbarPl){
-        Assert.assertEquals(sensorAddSnackbarPl, "Czujnik 61 nie został dodany." );
-    }
-    public void verifySensorAddSnackbarEn(String sensorAddSnackbarEn){
-        Assert.assertEquals(sensorAddSnackbarEn, "Sensor 61 could not be added." );
-    }
-
-    public boolean mapLoaded(WebElement webElement, int time){
-       return isElementDisplayed(driver, webElement, time);
-    }
-
-    public boolean snackBarExist(WebElement webElement, int time) {
+    public boolean snackBarExists(WebElement webElement, int time) {
         return isElementDisplayed(driver, webElement, time);
     }
 
     public void clickToAddPoint(int xOffset, int yOffset) {
         Actions builder = new Actions(driver);
         builder.moveToElement(homePlan, xOffset, yOffset).click().perform();
+    }
+
+    public void switchLanguage(String language){
+        if(language.toLowerCase().equals("en")){
+        clickElement(languageLabel);
+         clickElement(enLanguageLabel);}
+        else if(language.toLowerCase().equals("pl")){
+        clickElement(languageLabel);
+        clickElement(plLanguageLabel);}
+    }
+
+    public void verifyPlTranslation(SoftAssert appendTotalAssert) {
+        appendTotalAssert.assertEquals(getElementTranslations(languageLabel), "PL", "Domyślny język nie jest zgodny z językiem przeglądarki (polski)");
+        appendTotalAssert.assertEquals(getElementTranslations(title), "Smart Home", "Niepoprawne tłumaczenie tytułu strony");
+        appendTotalAssert.assertEquals(getElementTranslations(mainPanelTile), "PANEL GŁÓWNY", "Niepoprawne tłumaczenie zakładki DASHBOARD");
+        appendTotalAssert.assertEquals(getElementTranslations(hvacTile), "HVAC", "Niepoprawne tłumaczenie zakładki HVAC");
+        appendTotalAssert.assertEquals(getElementTranslations(authorsTile), "AUTORZY", "Niepoprawne tłumaczenie zakładki AUTHORS");
+        appendTotalAssert.assertEquals(getElementTranslations(title), "Smart Home", "Nazwa aplikacji nie powinna być tłumaczona.");
+    }
+
+    public void verifyEnTranslation(SoftAssert appendTotalAssert) {
+        appendTotalAssert.assertEquals(getElementTranslations(languageLabel), "EN", "Domyslny język nie jest językiem angielskim");
+        appendTotalAssert.assertEquals(getElementTranslations(title), "Smart Home", "Niepoprawne tłumaczenie tytułu strony");
+        appendTotalAssert.assertEquals(getElementTranslations(mainPanelTile), "DASHBOARD", "Niepoprawne tłumaczenie zakładki Panel główny");
+        appendTotalAssert.assertEquals(getElementTranslations(hvacTile), "HVAC", "Niepoprawne tłumaczenie zakładki HVAC");
+        appendTotalAssert.assertEquals(getElementTranslations(authorsTile), "AUTHORS", "Niepoprawne tłumaczenie zakładki Autorzy");
+        appendTotalAssert.assertEquals(getElementTranslations(title), "Smart Home", "Nazwa aplikacji nie powinna być tłumaczona.");
+    }
+
+    public void verifySnackbarsPl(SoftAssert appendTotalAssert) {
+        snackBarExists(snackBar, 10);
+        snackBarExists(snackBar2, 10);
+        appendTotalAssert.assertEquals(getElementTranslations(snackBar2), "Odświeżenie stanu czujników nie powiodło się.");
+        appendTotalAssert.assertEquals(getElementTranslations(snackBar), "Hej, coś nie styka! Sprawdź połączenie.");
+    }
+
+    public void verifySnackbarsPlAfterLanguageChange(SoftAssert appendTotalAssert) {
+        snackBarExists(snackBar, 10);
+        snackBarExists(snackBar2, 10);
+        appendTotalAssert.assertEquals(getElementTranslations(snackBar), "Odświeżenie stanu czujników nie powiodło się.");
+        appendTotalAssert.assertEquals(getElementTranslations(snackBar2), "Hej, coś nie styka! Sprawdź połączenie.");
+    }
+
+    public void verifySnackbarsEn(SoftAssert appendTotalAssert) {
+        snackBarExists(snackBar, 10);
+        snackBarExists(snackBar2, 10);
+        appendTotalAssert.assertEquals(getElementTranslations(snackBar2), "Could not refresh sensors' status.");
+        appendTotalAssert.assertEquals(getElementTranslations(snackBar), "Hey, something isn't quite right! Check your connection.");
+    }
+
+    public void verifyLoadMapPl(SoftAssert appendTotalAssert, String loadMapSnackBar, String refreshButton) {
+        appendTotalAssert.assertEquals(loadMapSnackBar, "Coś poszło nie tak....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home PL.");
+        appendTotalAssert.assertEquals(refreshButton, "ODŚWIEŻ", "Nieprawidłowa nazwa przycisku odświeżania PL.");
+    }
+
+    public void verifyLoadMapEn(SoftAssert appendTotalAssert, String loadMapSnackBar, String refreshButton) {
+        appendTotalAssert.assertEquals(loadMapSnackBar, "Something went wrong....", "Nieprawidłowy komunikat niepowodzenia wczytania mapy Home EN.");
+        appendTotalAssert.assertEquals(refreshButton, "REFRESH", "Nieprawidłowa nazwa przycisku odświeżania EN.");
+    }
+
+    public void verifyProximityWarningPl(){
+        Assert.assertEquals(getElementTranslations(sensorProximityWarning), "Potrzebny odstęp!\n" + "Zostaw większy odstęp między sensorami.\n" + "ZAMKNIJ", "Niepoprawne ostrzeżenie o zbyt bliskim umiejscowieniu sensorów po polsku.");
+    }
+
+    public void verifyProximityWarningEn(){
+        Assert.assertEquals(getElementTranslations(sensorProximityWarning), "Gap needed!\n" + "Leave a gap between sensors, please.\n" + "CLOSE", "Niepoprawne ostrzeżenie o zbyt bliskim umiejscowieniu sensorów po angielsku.");
     }
 }

--- a/src/test/java/selenium/DefaultLanguageTest.java
+++ b/src/test/java/selenium/DefaultLanguageTest.java
@@ -17,13 +17,13 @@ public class DefaultLanguageTest extends TestBase{
     }
     @Test
     public void defaultLanguageTest() throws IOException {
-        SoftAssert total_Assertion = new SoftAssert();
+        SoftAssert softAssert = new SoftAssert();
         languagePage.verifyChosenLanguageEn();
-        languagePage.verifyEnTranslation(total_Assertion);
+        languagePage.verifyEnTranslation(softAssert);
         languagePage.internetConnection(false);
-        languagePage.verifySnackbarsEn(total_Assertion);
+        languagePage.verifySnackbarsEn(softAssert);
         languagePage.internetConnection(true);
         languagePage.switchLanguage("pl");
-        total_Assertion.assertAll();
+        softAssert.assertAll();
     }
 }

--- a/src/test/java/selenium/DefaultLanguageTest.java
+++ b/src/test/java/selenium/DefaultLanguageTest.java
@@ -1,0 +1,31 @@
+package selenium;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import selenium.base.TestBase;
+import selenium.pages.LanguageDashboardPage;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class DefaultLanguageTest extends TestBase{
+    private LanguageDashboardPage languagePage;
+
+    @BeforeClass
+    public void startPage() {
+        languagePage = new LanguageDashboardPage(driver);
+        languagePage.goTo();
+    }
+    @Test
+    public void defaultLanguageTest() throws IOException {
+        Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "EN", "Język angielski nie jest językiem domyślnym.");
+        languagePage.verifyEnTranslation();
+        languagePage.internetConnection(false);
+        languagePage.verifySnackbarsEn();
+//        powrot do stanu poczatkowego
+        languagePage.internetConnection(true);
+        languagePage.clickElement(languagePage.languageLabel);
+        languagePage.clickElement(languagePage.plLanguageLabel);
+    }
+}

--- a/src/test/java/selenium/DefaultLanguageTest.java
+++ b/src/test/java/selenium/DefaultLanguageTest.java
@@ -1,13 +1,11 @@
 package selenium;
 
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
 import selenium.base.TestBase;
 import selenium.pages.LanguageDashboardPage;
-
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 public class DefaultLanguageTest extends TestBase{
     private LanguageDashboardPage languagePage;
@@ -19,13 +17,13 @@ public class DefaultLanguageTest extends TestBase{
     }
     @Test
     public void defaultLanguageTest() throws IOException {
-        Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "EN", "Język angielski nie jest językiem domyślnym.");
-        languagePage.verifyEnTranslation();
+        SoftAssert total_Assertion = new SoftAssert();
+        languagePage.verifyChosenLanguageEn();
+        languagePage.verifyEnTranslation(total_Assertion);
         languagePage.internetConnection(false);
-        languagePage.verifySnackbarsEn();
+        languagePage.verifySnackbarsEn(total_Assertion);
 //        powrot do stanu poczatkowego
         languagePage.internetConnection(true);
-        languagePage.clickElement(languagePage.languageLabel);
-        languagePage.clickElement(languagePage.plLanguageLabel);
+        languagePage.switchLanguage("pl");
     }
 }

--- a/src/test/java/selenium/DefaultLanguageTest.java
+++ b/src/test/java/selenium/DefaultLanguageTest.java
@@ -22,8 +22,8 @@ public class DefaultLanguageTest extends TestBase{
         languagePage.verifyEnTranslation(total_Assertion);
         languagePage.internetConnection(false);
         languagePage.verifySnackbarsEn(total_Assertion);
-//        powrot do stanu poczatkowego
         languagePage.internetConnection(true);
         languagePage.switchLanguage("pl");
+        total_Assertion.assertAll();
     }
 }

--- a/src/test/java/selenium/LanguagesTest.java
+++ b/src/test/java/selenium/LanguagesTest.java
@@ -18,18 +18,18 @@ public class LanguagesTest extends TestBase {
     }
 
     @Test(priority = 0)
-    public void languageLabelsAndSnackbarsTest () throws IOException, InterruptedException {
-        SoftAssert total_Assertion = new SoftAssert();
+    public void languageLabelsAndSnackbarsTest () throws IOException {
+        SoftAssert softAssert = new SoftAssert();
         languagePage.mapExists();
         languagePage.languageLabelExists();
-        languagePage.verifyPlTranslation(total_Assertion);
+        languagePage.verifyPlTranslation(softAssert);
         languagePage.internetConnection(false);
-        languagePage.verifySnackbarsPl(total_Assertion);
+        languagePage.verifySnackbarsPl(softAssert);
         languagePage.switchLanguage("en");
-        languagePage.verifyEnTranslation(total_Assertion);
-        languagePage.verifySnackbarsEn(total_Assertion);
+        languagePage.verifyEnTranslation(softAssert);
+        languagePage.verifySnackbarsEn(softAssert);
         languagePage.switchLanguage("pl");
-        languagePage.verifySnackbarsPlAfterLanguageChange(total_Assertion);
+        languagePage.verifySnackbarsPlAfterLanguageChange(softAssert);
         languagePage.internetConnection(true);
         languagePage.clickSensor1();
         languagePage.clickToAddPoint(-50, -75);
@@ -48,33 +48,33 @@ public class LanguagesTest extends TestBase {
         languagePage.languageLabelExists();
         languagePage.internetConnection(false);
         languagePage.switchLanguage("pl");
-        languagePage.verifyLoadMapPl(total_Assertion);
+        languagePage.verifyLoadMapPl(softAssert);
         languagePage.switchLanguage("en");
-        languagePage.verifyLoadMapEn(total_Assertion);
+        languagePage.verifyLoadMapEn(softAssert);
         languagePage.internetConnection(true);
         languagePage.switchLanguage("pl");
-        total_Assertion.assertAll();
+        softAssert.assertAll();
     }
 
     @Test(priority = 1)
     public void languageChoiceMemory () throws IOException {
-        SoftAssert total_Assertion = new SoftAssert();
+        SoftAssert softAssert = new SoftAssert();
         languagePage.goTo();
         languagePage.languageLabelExists();
         languagePage.mapExists();
         languagePage.verifyChosenLanguagePl();
-        languagePage.verifyPlTranslation(total_Assertion);
+        languagePage.verifyPlTranslation(softAssert);
         languagePage.switchLanguage("en");
-        languagePage.verifyEnTranslation(total_Assertion);
+        languagePage.verifyEnTranslation(softAssert);
         languagePage.internetConnection(false);
-        languagePage.verifySnackbarsEn(total_Assertion);
+        languagePage.verifySnackbarsEn(softAssert);
         languagePage.internetConnection(true);
         languagePage.goTo();
         languagePage.languageLabelExists();
         languagePage.verifyChosenLanguageEn();
-        languagePage.verifyEnTranslation(total_Assertion);
+        languagePage.verifyEnTranslation(softAssert);
         languagePage.internetConnection(true);
         languagePage.switchLanguage("pl");
-        total_Assertion.assertAll();
+        softAssert.assertAll();
     }
 }

--- a/src/test/java/selenium/LanguagesTest.java
+++ b/src/test/java/selenium/LanguagesTest.java
@@ -22,14 +22,11 @@ public class LanguagesTest extends TestBase {
 
     @Test(priority = 0)
     public void languageLabelsAndSnackbarsTest () throws IOException, InterruptedException {
-        WebDriverWait wait = new WebDriverWait(driver, 5000);
-        wait.until(ExpectedConditions.visibilityOf(languagePage.homePlan));
+        languagePage.mapLoaded(languagePage.homePlan, 5);
         languagePage.waitingForLanguageLabelVisibility();
-        Thread.sleep(10000);
-//        Sprawdzanie poprawności tłumaczenia labelek i komunikatów, także przy zmianie języka, gdy nie ma połączenai internetowego
-//        languagePage.internetConnection(false);
+//          Sprawdzanie poprawności tłumaczenia labelek i komunikatów, także przy zmianie języka, gdy nie ma połączenai internetowego
         languagePage.verifyPlTranslation();
-//        languagePage.internetConnection(false);
+        languagePage.internetConnection(false);
         languagePage.verifySnackbarsPl();
         languagePage.clickElement(languagePage.languageLabel);
         languagePage.clickElement(languagePage.enLanguageLabel);
@@ -40,12 +37,14 @@ public class LanguagesTest extends TestBase {
         languagePage.verifySnackbarsPlAfterLanguageChange();
         languagePage.clickElement(languagePage.sensor1);
         languagePage.clickToAddPoint(-50, -75);
-//Tu chcę zaimplementować metodę, która będzie sprawdzać treść snacka o nieudanym umijecowieniu czujnika. Obecnie tego nie robię, gdyż metoda powinna być zmieniona na bardziej generyczną
+//          Tu chcę zaimplementować kod, który będzie sprawdzać treść snacka o nieudanym umiejscowieniu czujnika.
+//          Obecnie tego nie robię, gdyż taki kod powinien być bardziej generyczny.
         languagePage.internetConnection(true);
+        Thread.sleep(1000);
         languagePage.goTo();
         languagePage.internetConnection(false);
-//       Sprawdzenie komunikatu o nieudanym załadowaniu mapy Home oraz tłumaczenia przycisku odświeżania
-//       Zmieniany jest też język, aby sprawdzić te 2 napisy w wersji angielskiej
+//         Sprawdzenie komunikatu o nieudanym załadowaniu mapy Home oraz tłumaczenia przycisku odświeżania
+//         Zmieniany jest też język, aby sprawdzić te 2 napisy w wersji angielskiej
         String loadMapSnackBar = languagePage.loadMapSnackBar.getText();
         String refreshButton = languagePage.refreshButton.getText();
         languagePage.verifyLoadMapPl(loadMapSnackBar, refreshButton);
@@ -58,16 +57,15 @@ public class LanguagesTest extends TestBase {
         languagePage.internetConnection(true);
         languagePage.clickElement(languagePage.languageLabel);
         languagePage.clickElement(languagePage.plLanguageLabel);
-       }
+    }
 
     @Test(priority = 1)
     public void languageChoiceMemory () throws IOException, InterruptedException {
+//        Test sprawdza, czy strona zapamiętuje wybór użytkownika w kontekście wybranego wcześniej języka.
         languagePage.goTo();
         languagePage.waitingForLanguageLabelVisibility();
-        WebDriverWait wait = new WebDriverWait(driver, 5000);
-        wait.until(ExpectedConditions.visibilityOf(languagePage.homePlan));
+        languagePage.mapLoaded(languagePage.homePlan, 5);
         Thread.sleep(1000);
-//        Test sprawdza, czy strona zapamiętuje wybór użytkownika w kontekście wybranego wcześniej języka.
         Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "PL", "Przeglądarka nie jest odpalona w języku polskim.");
         languagePage.verifyPlTranslation();
         languagePage.clickElement(languagePage.languageLabel);
@@ -80,27 +78,9 @@ public class LanguagesTest extends TestBase {
         languagePage.waitingForLanguageLabelVisibility();
         Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "EN", "Nie zapamiętano uprzednio wybranego języka");
         languagePage.verifyEnTranslation();
-        //        powrot do stanu poczatkowego
+//          powrot do stanu poczatkowego
         languagePage.internetConnection(true);
         languagePage.clickElement(languagePage.languageLabel);
         languagePage.clickElement(languagePage.plLanguageLabel);
     }
-
-    @Test(priority = 2)
-    public void defaultLanguageTest() throws IOException {
-//        Ten będzie działał na 100% dobrze jak tylko zaimplementuę metodę z wywoływaniem zestawu testów z parametrem dla języka.
-        Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "EN", "Język angielski nie jest językiem domyślnym.");
-        languagePage.verifyEnTranslation();
-        languagePage.internetConnection(false);
-        languagePage.verifySnackbarsEn();
-//        powrot do stanu poczatkowego
-        languagePage.internetConnection(true);
-        languagePage.clickElement(languagePage.languageLabel);
-        languagePage.clickElement(languagePage.plLanguageLabel);
-
-    }
-//        listOfSensorsNames = languagePage.getSensorStrings();
-//        Assert.assertEquals(listOfSensorsNames, correctListTranslationPl, "Nieprawidłowości w tłumaczeniu tytułów list lub nazw i wartości czujników" );
-//        listOfSensorsNames = languagePage.getSensorStrings();
-//        Assert.assertEquals(listOfSensorsNames, correctListTranslationPl, "Nieprawidłowości w tłumaczeniu tytułów list lub nazw i wartości czujników" );
 }

--- a/src/test/java/selenium/LanguagesTest.java
+++ b/src/test/java/selenium/LanguagesTest.java
@@ -31,41 +31,37 @@ public class LanguagesTest extends TestBase {
         languagePage.switchLanguage("pl");
         languagePage.verifySnackbarsPlAfterLanguageChange(total_Assertion);
         languagePage.internetConnection(true);
-        languagePage.clickElement(languagePage.sensor1);
+        languagePage.clickSensor1();
         languagePage.clickToAddPoint(-50, -75);
-        languagePage.clickElement(languagePage.sensor2);
-        languagePage.clickToAddPoint(-70, -95);
+        languagePage.clickSensor2();
+        languagePage.clickToAddPoint(-60, -85);
         languagePage.verifyProximityWarningPl();
-        languagePage.clickElement(languagePage.sensorProximityWarningExitButton);
+        languagePage.clickSensorProximityWarningExitButton();
         languagePage.switchLanguage("en");
-        languagePage.clickElement(languagePage.sensor3);
+        languagePage.languageLabelExists();
+        languagePage.clickSensor3();
         languagePage.clickToAddPoint(90, 100);
-        languagePage.clickElement(languagePage.sensor4);
-        languagePage.clickToAddPoint(110, 120);
+        languagePage.clickSensor4();
+        languagePage.clickToAddPoint(100, 110);
         languagePage.verifyProximityWarningEn();
         languagePage.goTo();
         languagePage.languageLabelExists();
         languagePage.internetConnection(false);
         languagePage.switchLanguage("pl");
-        String loadMapSnackBar = languagePage.getElementTranslations(languagePage.loadMapSnackBar);
-        String refreshButton = languagePage.getElementTranslations(languagePage.refreshButton);
-        languagePage.verifyLoadMapPl(total_Assertion, loadMapSnackBar, refreshButton);
+        languagePage.verifyLoadMapPl(total_Assertion);
         languagePage.switchLanguage("en");
-        loadMapSnackBar = languagePage.getElementTranslations(languagePage.loadMapSnackBar);
-        refreshButton = languagePage.getElementTranslations(languagePage.refreshButton);
-        languagePage.verifyLoadMapEn(total_Assertion, loadMapSnackBar, refreshButton);
+        languagePage.verifyLoadMapEn(total_Assertion);
         languagePage.internetConnection(true);
         languagePage.switchLanguage("pl");
         total_Assertion.assertAll();
     }
 
     @Test(priority = 1)
-    public void languageChoiceMemory () throws IOException, InterruptedException {
+    public void languageChoiceMemory () throws IOException {
         SoftAssert total_Assertion = new SoftAssert();
         languagePage.goTo();
         languagePage.languageLabelExists();
         languagePage.mapExists();
-//        Thread.sleep(1000);
         languagePage.verifyChosenLanguagePl();
         languagePage.verifyPlTranslation(total_Assertion);
         languagePage.switchLanguage("en");

--- a/src/test/java/selenium/LanguagesTest.java
+++ b/src/test/java/selenium/LanguagesTest.java
@@ -1,12 +1,11 @@
 package selenium;
 
+import org.testng.asserts.SoftAssert;
 import selenium.base.TestBase;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import selenium.pages.LanguageDashboardPage;
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 public class LanguagesTest extends TestBase {
     private LanguageDashboardPage languagePage;
@@ -14,71 +13,72 @@ public class LanguagesTest extends TestBase {
     @BeforeClass
     public void startPage() {
         languagePage = new LanguageDashboardPage(driver);
+        languagePage.removeAllSensorsFromMap();
         languagePage.goTo();
-        driver.manage().timeouts().implicitlyWait(10000, TimeUnit.MILLISECONDS);
     }
 
     @Test(priority = 0)
     public void languageLabelsAndSnackbarsTest () throws IOException, InterruptedException {
-        languagePage.mapLoaded(languagePage.homePlan, 5);
-        languagePage.waitingForLanguageLabelVisibility();
-//          Sprawdzanie poprawności tłumaczenia labelek i komunikatów, także przy zmianie języka, gdy nie ma połączenai internetowego
-        languagePage.verifyPlTranslation();
+        SoftAssert total_Assertion = new SoftAssert();
+        languagePage.mapExists();
+        languagePage.languageLabelExists();
+        languagePage.verifyPlTranslation(total_Assertion);
         languagePage.internetConnection(false);
-        languagePage.verifySnackbarsPl();
-        languagePage.clickElement(languagePage.languageLabel);
-        languagePage.clickElement(languagePage.enLanguageLabel);
-        languagePage.verifyEnTranslation();
-        languagePage.verifySnackbarsEn();
-        languagePage.clickElement(languagePage.languageLabel);
-        languagePage.clickElement(languagePage.plLanguageLabel);
-        languagePage.verifySnackbarsPlAfterLanguageChange();
+        languagePage.verifySnackbarsPl(total_Assertion);
+        languagePage.switchLanguage("en");
+        languagePage.verifyEnTranslation(total_Assertion);
+        languagePage.verifySnackbarsEn(total_Assertion);
+        languagePage.switchLanguage("pl");
+        languagePage.verifySnackbarsPlAfterLanguageChange(total_Assertion);
+        languagePage.internetConnection(true);
         languagePage.clickElement(languagePage.sensor1);
         languagePage.clickToAddPoint(-50, -75);
-//          Tu chcę zaimplementować kod, który będzie sprawdzać treść snacka o nieudanym umiejscowieniu czujnika.
-//          Obecnie tego nie robię, gdyż taki kod powinien być bardziej generyczny.
-        languagePage.internetConnection(true);
-        Thread.sleep(1000);
+        languagePage.clickElement(languagePage.sensor2);
+        languagePage.clickToAddPoint(-70, -95);
+        languagePage.verifyProximityWarningPl();
+        languagePage.clickElement(languagePage.sensorProximityWarningExitButton);
+        languagePage.switchLanguage("en");
+        languagePage.clickElement(languagePage.sensor3);
+        languagePage.clickToAddPoint(90, 100);
+        languagePage.clickElement(languagePage.sensor4);
+        languagePage.clickToAddPoint(110, 120);
+        languagePage.verifyProximityWarningEn();
         languagePage.goTo();
+        languagePage.languageLabelExists();
         languagePage.internetConnection(false);
-//         Sprawdzenie komunikatu o nieudanym załadowaniu mapy Home oraz tłumaczenia przycisku odświeżania
-//         Zmieniany jest też język, aby sprawdzić te 2 napisy w wersji angielskiej
-        String loadMapSnackBar = languagePage.loadMapSnackBar.getText();
-        String refreshButton = languagePage.refreshButton.getText();
-        languagePage.verifyLoadMapPl(loadMapSnackBar, refreshButton);
-        languagePage.clickElement(languagePage.languageLabel);
-        languagePage.clickElement(languagePage.enLanguageLabel);
-        loadMapSnackBar = languagePage.loadMapSnackBar.getText();
-        refreshButton = languagePage.refreshButton.getText();
-        languagePage.verifyLoadMapEn(loadMapSnackBar, refreshButton);
-//        powrot do stanu poczatkowego
+        languagePage.switchLanguage("pl");
+        String loadMapSnackBar = languagePage.getElementTranslations(languagePage.loadMapSnackBar);
+        String refreshButton = languagePage.getElementTranslations(languagePage.refreshButton);
+        languagePage.verifyLoadMapPl(total_Assertion, loadMapSnackBar, refreshButton);
+        languagePage.switchLanguage("en");
+        loadMapSnackBar = languagePage.getElementTranslations(languagePage.loadMapSnackBar);
+        refreshButton = languagePage.getElementTranslations(languagePage.refreshButton);
+        languagePage.verifyLoadMapEn(total_Assertion, loadMapSnackBar, refreshButton);
         languagePage.internetConnection(true);
-        languagePage.clickElement(languagePage.languageLabel);
-        languagePage.clickElement(languagePage.plLanguageLabel);
+        languagePage.switchLanguage("pl");
+        total_Assertion.assertAll();
     }
 
     @Test(priority = 1)
     public void languageChoiceMemory () throws IOException, InterruptedException {
-//        Test sprawdza, czy strona zapamiętuje wybór użytkownika w kontekście wybranego wcześniej języka.
+        SoftAssert total_Assertion = new SoftAssert();
         languagePage.goTo();
-        languagePage.waitingForLanguageLabelVisibility();
-        languagePage.mapLoaded(languagePage.homePlan, 5);
-        Thread.sleep(1000);
-        Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "PL", "Przeglądarka nie jest odpalona w języku polskim.");
-        languagePage.verifyPlTranslation();
-        languagePage.clickElement(languagePage.languageLabel);
-        languagePage.clickElement(languagePage.enLanguageLabel);
-        languagePage.verifyEnTranslation();
+        languagePage.languageLabelExists();
+        languagePage.mapExists();
+//        Thread.sleep(1000);
+        languagePage.verifyChosenLanguagePl();
+        languagePage.verifyPlTranslation(total_Assertion);
+        languagePage.switchLanguage("en");
+        languagePage.verifyEnTranslation(total_Assertion);
         languagePage.internetConnection(false);
-        languagePage.verifySnackbarsEn();
+        languagePage.verifySnackbarsEn(total_Assertion);
         languagePage.internetConnection(true);
         languagePage.goTo();
-        languagePage.waitingForLanguageLabelVisibility();
-        Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "EN", "Nie zapamiętano uprzednio wybranego języka");
-        languagePage.verifyEnTranslation();
-//          powrot do stanu poczatkowego
+        languagePage.languageLabelExists();
+        languagePage.verifyChosenLanguageEn();
+        languagePage.verifyEnTranslation(total_Assertion);
         languagePage.internetConnection(true);
-        languagePage.clickElement(languagePage.languageLabel);
-        languagePage.clickElement(languagePage.plLanguageLabel);
+        languagePage.switchLanguage("pl");
+        total_Assertion.assertAll();
     }
 }

--- a/src/test/java/selenium/LanguagesTest.java
+++ b/src/test/java/selenium/LanguagesTest.java
@@ -1,0 +1,106 @@
+package selenium;
+
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import selenium.base.TestBase;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import selenium.pages.LanguageDashboardPage;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class LanguagesTest extends TestBase {
+    private LanguageDashboardPage languagePage;
+
+    @BeforeClass
+    public void startPage() {
+        languagePage = new LanguageDashboardPage(driver);
+        languagePage.goTo();
+        driver.manage().timeouts().implicitlyWait(10000, TimeUnit.MILLISECONDS);
+    }
+
+    @Test(priority = 0)
+    public void languageLabelsAndSnackbarsTest () throws IOException, InterruptedException {
+        WebDriverWait wait = new WebDriverWait(driver, 5000);
+        wait.until(ExpectedConditions.visibilityOf(languagePage.homePlan));
+        languagePage.waitingForLanguageLabelVisibility();
+        Thread.sleep(10000);
+//        Sprawdzanie poprawności tłumaczenia labelek i komunikatów, także przy zmianie języka, gdy nie ma połączenai internetowego
+//        languagePage.internetConnection(false);
+        languagePage.verifyPlTranslation();
+//        languagePage.internetConnection(false);
+        languagePage.verifySnackbarsPl();
+        languagePage.clickElement(languagePage.languageLabel);
+        languagePage.clickElement(languagePage.enLanguageLabel);
+        languagePage.verifyEnTranslation();
+        languagePage.verifySnackbarsEn();
+        languagePage.clickElement(languagePage.languageLabel);
+        languagePage.clickElement(languagePage.plLanguageLabel);
+        languagePage.verifySnackbarsPlAfterLanguageChange();
+        languagePage.clickElement(languagePage.sensor1);
+        languagePage.clickToAddPoint(-50, -75);
+//Tu chcę zaimplementować metodę, która będzie sprawdzać treść snacka o nieudanym umijecowieniu czujnika. Obecnie tego nie robię, gdyż metoda powinna być zmieniona na bardziej generyczną
+        languagePage.internetConnection(true);
+        languagePage.goTo();
+        languagePage.internetConnection(false);
+//       Sprawdzenie komunikatu o nieudanym załadowaniu mapy Home oraz tłumaczenia przycisku odświeżania
+//       Zmieniany jest też język, aby sprawdzić te 2 napisy w wersji angielskiej
+        String loadMapSnackBar = languagePage.loadMapSnackBar.getText();
+        String refreshButton = languagePage.refreshButton.getText();
+        languagePage.verifyLoadMapPl(loadMapSnackBar, refreshButton);
+        languagePage.clickElement(languagePage.languageLabel);
+        languagePage.clickElement(languagePage.enLanguageLabel);
+        loadMapSnackBar = languagePage.loadMapSnackBar.getText();
+        refreshButton = languagePage.refreshButton.getText();
+        languagePage.verifyLoadMapEn(loadMapSnackBar, refreshButton);
+//        powrot do stanu poczatkowego
+        languagePage.internetConnection(true);
+        languagePage.clickElement(languagePage.languageLabel);
+        languagePage.clickElement(languagePage.plLanguageLabel);
+       }
+
+    @Test(priority = 1)
+    public void languageChoiceMemory () throws IOException, InterruptedException {
+        languagePage.goTo();
+        languagePage.waitingForLanguageLabelVisibility();
+        WebDriverWait wait = new WebDriverWait(driver, 5000);
+        wait.until(ExpectedConditions.visibilityOf(languagePage.homePlan));
+        Thread.sleep(1000);
+//        Test sprawdza, czy strona zapamiętuje wybór użytkownika w kontekście wybranego wcześniej języka.
+        Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "PL", "Przeglądarka nie jest odpalona w języku polskim.");
+        languagePage.verifyPlTranslation();
+        languagePage.clickElement(languagePage.languageLabel);
+        languagePage.clickElement(languagePage.enLanguageLabel);
+        languagePage.verifyEnTranslation();
+        languagePage.internetConnection(false);
+        languagePage.verifySnackbarsEn();
+        languagePage.internetConnection(true);
+        languagePage.goTo();
+        languagePage.waitingForLanguageLabelVisibility();
+        Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "EN", "Nie zapamiętano uprzednio wybranego języka");
+        languagePage.verifyEnTranslation();
+        //        powrot do stanu poczatkowego
+        languagePage.internetConnection(true);
+        languagePage.clickElement(languagePage.languageLabel);
+        languagePage.clickElement(languagePage.plLanguageLabel);
+    }
+
+    @Test(priority = 2)
+    public void defaultLanguageTest() throws IOException {
+//        Ten będzie działał na 100% dobrze jak tylko zaimplementuę metodę z wywoływaniem zestawu testów z parametrem dla języka.
+        Assert.assertEquals(languagePage.getElementTranslations(languagePage.languageLabel), "EN", "Język angielski nie jest językiem domyślnym.");
+        languagePage.verifyEnTranslation();
+        languagePage.internetConnection(false);
+        languagePage.verifySnackbarsEn();
+//        powrot do stanu poczatkowego
+        languagePage.internetConnection(true);
+        languagePage.clickElement(languagePage.languageLabel);
+        languagePage.clickElement(languagePage.plLanguageLabel);
+
+    }
+//        listOfSensorsNames = languagePage.getSensorStrings();
+//        Assert.assertEquals(listOfSensorsNames, correctListTranslationPl, "Nieprawidłowości w tłumaczeniu tytułów list lub nazw i wartości czujników" );
+//        listOfSensorsNames = languagePage.getSensorStrings();
+//        Assert.assertEquals(listOfSensorsNames, correctListTranslationPl, "Nieprawidłowości w tłumaczeniu tytułów list lub nazw i wartości czujników" );
+}

--- a/src/test/java/selenium/LanguagesTest.java
+++ b/src/test/java/selenium/LanguagesTest.java
@@ -1,7 +1,5 @@
 package selenium;
 
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import selenium.base.TestBase;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;

--- a/suites/languagesTest.xml
+++ b/suites/languagesTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Languages suite">
+    <test name="Spanish language test">
+    <parameter name="browserLanguage" value="es"/>
+    <classes>
+        <class name="selenium.DefaultLanguageTest"></class>
+    </classes>
+</test>
+    <test name="Other language tests">
+        <classes>
+            <class name="selenium.LanguagesTest"></class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Testy dla języków na stronie JS. Te testy, tak jak kiedyś wspominałem, nie sprawdzają jeszcze tłumaczenia sensorów. Sprawdzają natomiast zapamiętywanie wyboru języka, język domyślny i elementy snackbarów, komunikatu o braku możliwości załadowania mapy i innych elementów, które można przetłumaczyć. 